### PR TITLE
feat(asabr-adapter): initialize A-SABR adapter with routing capabilit…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,8 +255,15 @@ else()
     set(USING_CSP_STUBS TRUE)
 endif()
 
+# Canonical C sources shared with cspcl-sys
+set(CSPCL_C_SOURCE_DIR ${CMAKE_SOURCE_DIR}/rust-bindings/cspcl-sys/c_src)
+
 # CSPCL library
-set(CSPCL_SOURCES src/cspcl.c)
+set(CSPCL_SOURCES
+    ${CSPCL_C_SOURCE_DIR}/cspcl.c
+    ${CSPCL_C_SOURCE_DIR}/cspcl_route_bridge.c
+    ${CSPCL_C_SOURCE_DIR}/cspcl_asabr_process_provider.c
+)
 
 # Add stub implementation when not using system CSP
 if(USING_CSP_STUBS)
@@ -267,7 +274,7 @@ add_library(cspcl ${CSPCL_SOURCES})
 
 target_include_directories(cspcl
     PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
+        $<BUILD_INTERFACE:${CSPCL_C_SOURCE_DIR}>
         $<INSTALL_INTERFACE:include>
     PRIVATE
         ${CSP_ALL_INCLUDE_DIRS}
@@ -310,7 +317,11 @@ install(TARGETS cspcl
     ARCHIVE DESTINATION lib
 )
 
-install(FILES src/cspcl.h src/cspcl_config.h
+install(FILES
+    ${CSPCL_C_SOURCE_DIR}/cspcl.h
+    ${CSPCL_C_SOURCE_DIR}/cspcl_config.h
+    ${CSPCL_C_SOURCE_DIR}/cspcl_route_bridge.h
+    ${CSPCL_C_SOURCE_DIR}/cspcl_asabr_process_provider.h
     DESTINATION include
 )
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ CSP's small MTU without requiring changes to either stack.
 - [Rust API Reference]({% link api/rust.md %}) — Rust crate documentation
 - [uD3TN Integration]({% link integration/ud3tn.md %}) — use CSPCL inside uD3TN
 - [Unibo Integration]({% link integration/unibo.md %}) — use CSPCL with Unibo-BP
+- [A-SABR Adapter]({% link integration/asabr.md %}) — use CSPCL with A-SABR
 - [Architecture]({% link architecture.md %}) — design decisions and protocol stack
 
 ---

--- a/docs/integration/asabr.md
+++ b/docs/integration/asabr.md
@@ -1,0 +1,19 @@
+---
+layout: default
+title: ASABR Adapter
+nav_order: 3
+parent: BP Integrations
+permalink: /integration/asabr/
+---
+
+# ASABR Adapter
+
+This page redirects to the upstream A-SABR repository for full documentation.
+
+<script>
+  window.location.replace("https://github.com/DTN-MTP/A-SABR");
+</script>
+
+If you are not redirected automatically, open:
+
+- [A-SABR on GitHub](https://github.com/DTN-MTP/A-SABR)

--- a/docs/integration/unibo.md
+++ b/docs/integration/unibo.md
@@ -10,6 +10,10 @@ permalink: /integration/unibo/
 
 This guide explains how to integrate CSPCL (CubeSat Space Protocol Convergence Layer) with Unibo-BP to enable Bundle Protocol communication over CSP using the ZMQHUB interface.
 
+## ASABR Adapter
+
+The Unibo integration supports ASABR-backed route selection through the CSPCL adapter process provider.
+
 ## Architecture
 
 ```bash
@@ -88,21 +92,22 @@ ls -la build/
 The CSPCLA daemon is a standalone executable that bridges Unibo-BP with libcsp over ZMQHUB.
 
 ```bash
-cd /path/to/cspcl/unibo-integration
+cd "$INTEG_DIR"
 mkdir -p build
 
 gcc -O2 -Wall -Wextra \
-  src/cspcl_daemon.c ../src/cspcl.c \
+  src/cspcl_daemon.c $CSPCL_C_SRC/cspcl.c \
+  $CSPCL_C_SRC/cspcl_route_bridge.c $CSPCL_C_SRC/cspcl_asabr_process_provider.c \
   -o build/unibo-bp-cspcl \
-  -I../src \
-  -I/path/to/unibo-bp/include \
-  -I/path/to/libcsp/include \
-  -I/path/to/libcsp/build/include \
-  -L/path/to/unibo-bp/build/Unibo-BP/lib \
-  -Wl,-rpath,/path/to/unibo-bp/build/Unibo-BP/lib \
+  -I$CSPCL_C_SRC \
+  -I$DTN_ROOT/unibo-dtn/unibo-bp/include \
+  -I$DTN_ROOT/libcsp/include \
+  -I$DTN_ROOT/libcsp/build/include \
+  -L$UNIBO_BP_LIB \
+  -Wl,-rpath,$UNIBO_BP_LIB \
   -lunibo-bp-api \
-  /path/to/libcsp/build/libcsp.a \
-  -lzmq -lpthread -lm
+  $LIBCSP_BUILD/libcsp.a \
+  -lzmq -lpthread -lm -lsocketcan
 
 # Verify build
 ls -la build/unibo-bp-cspcl
@@ -114,20 +119,21 @@ file build/unibo-bp-cspcl
 If you use CAN instead of ZMQHUB, compile the daemon with SocketCAN support:
 
 ```bash
-cd /path/to/cspcl/unibo-integration
+cd "$INTEG_DIR"
 mkdir -p build
 
 gcc -O2 -Wall -Wextra \
-  src/cspcl_daemon.c ../src/cspcl.c \
+  src/cspcl_daemon.c $CSPCL_C_SRC/cspcl.c \
+  $CSPCL_C_SRC/cspcl_route_bridge.c $CSPCL_C_SRC/cspcl_asabr_process_provider.c \
   -o build/unibo-bp-cspcl \
-  -I../src \
-  -I/path/to/unibo-bp/include \
-  -I/path/to/libcsp/include \
-  -I/path/to/libcsp/build/include \
-  -L/path/to/unibo-bp/build/Unibo-BP/lib \
-  -Wl,-rpath,/path/to/unibo-bp/build/Unibo-BP/lib \
+  -I$CSPCL_C_SRC \
+  -I$DTN_ROOT/unibo-dtn/unibo-bp/include \
+  -I$DTN_ROOT/libcsp/include \
+  -I$DTN_ROOT/libcsp/build/include \
+  -L$UNIBO_BP_LIB \
+  -Wl,-rpath,$UNIBO_BP_LIB \
   -lunibo-bp-api \
-  /path/to/libcsp/build/libcsp.a \
+  $LIBCSP_BUILD/libcsp.a \
   -lzmq -lpthread -lm \
   -lsocketcan
 ```
@@ -148,10 +154,27 @@ export LIBCSP_BUILD=$DTN_ROOT/libcsp/build
 EOF
 
 source ~/.bashrc
+export CSPCL_C_SRC=$CSPCL_DIR/rust-bindings/cspcl-sys/c_src
 
 # Optional: Enable CSPCL tracing (recommended for debugging)
 export CSPCLA_TRACE_PAYLOAD=1
 export CSPCLA_TRACE_BYTES=64
+
+# Required to enable ASABR route provider in unibo-bp-cspcl
+export CSPCL_ASABR_ADAPTER_BIN=$CSPCL_DIR/rust-bindings/target/release/cspcl-asabr-adapter
+
+# Use an epoch-time-compatible contact plan for live tests
+cat > /tmp/asabr-dtn-dynamic3.cp <<'EOF'
+node 0 n0
+node 1 n1
+node 2 n2
+contact 1 2 0 4000000000 evl 1000000 1
+EOF
+export CSPCL_ASABR_CONTACT_PLAN_PATH=/tmp/asabr-dtn-dynamic3.cp
+
+# Build adapter binary if not already built
+cd "$CSPCL_DIR/rust-bindings"
+cargo build --release -p cspcl-asabr-adapter
 ```
 
 ## Testing Bundle Transfer
@@ -194,20 +217,32 @@ The `broker_type` is interface-dependent:
 
 ```bash
 # Node 1 (CSP addr 1)
-./build/unibo-bp-cspcl 1 10 zmqhub 2001 /tmp/unibo-node1
+stdbuf -oL -eL env \
+  CSPCL_ASABR_ADAPTER_BIN="$CSPCL_ASABR_ADAPTER_BIN" \
+  CSPCL_ASABR_CONTACT_PLAN_PATH="$CSPCL_ASABR_CONTACT_PLAN_PATH" \
+  ./build/unibo-bp-cspcl 1 10 zmqhub 2001 /tmp/unibo-node1
 
 # Node 2 (CSP addr 2)
-./build/unibo-bp-cspcl 2 10 zmqhub 2002 /tmp/unibo-node2
+stdbuf -oL -eL env \
+  CSPCL_ASABR_ADAPTER_BIN="$CSPCL_ASABR_ADAPTER_BIN" \
+  CSPCL_ASABR_CONTACT_PLAN_PATH="$CSPCL_ASABR_CONTACT_PLAN_PATH" \
+  ./build/unibo-bp-cspcl 2 10 zmqhub 2002 /tmp/unibo-node2
 ```
 
 For CAN, use the same command shape and switch `broker_type`:
 
 ```bash
 # Node 1 (CAN)
-./build/unibo-bp-cspcl 1 10 can 2001 /tmp/unibo-node1
+stdbuf -oL -eL env \
+  CSPCL_ASABR_ADAPTER_BIN="$CSPCL_ASABR_ADAPTER_BIN" \
+  CSPCL_ASABR_CONTACT_PLAN_PATH="$CSPCL_ASABR_CONTACT_PLAN_PATH" \
+  ./build/unibo-bp-cspcl 1 10 can 2001 /tmp/unibo-node1
 
 # Node 2 (CAN)
-./build/unibo-bp-cspcl 2 10 can 2002 /tmp/unibo-node2
+stdbuf -oL -eL env \
+  CSPCL_ASABR_ADAPTER_BIN="$CSPCL_ASABR_ADAPTER_BIN" \
+  CSPCL_ASABR_CONTACT_PLAN_PATH="$CSPCL_ASABR_CONTACT_PLAN_PATH" \
+  ./build/unibo-bp-cspcl 2 10 can 2002 /tmp/unibo-node2
 ```
 
 ## Troubleshooting
@@ -238,8 +273,14 @@ ldd ./build/unibo-bp-cspcl | grep unibo-bp-api
 pkill -9 -f 'unibo-bp-cspcl'
 
 # Restart daemons
-nohup stdbuf -oL -eL ./build/unibo-bp-cspcl 1 10 zmqhub 2001 /tmp/unibo-node1 > /tmp/cspcl-node1.log 2>&1 &
-nohup stdbuf -oL -eL ./build/unibo-bp-cspcl 2 10 zmqhub 2002 /tmp/unibo-node2 > /tmp/cspcl-node2.log 2>&1 &
+nohup stdbuf -oL -eL env \
+  CSPCL_ASABR_ADAPTER_BIN="$CSPCL_ASABR_ADAPTER_BIN" \
+  CSPCL_ASABR_CONTACT_PLAN_PATH="$CSPCL_ASABR_CONTACT_PLAN_PATH" \
+  ./build/unibo-bp-cspcl 1 10 zmqhub 2001 /tmp/unibo-node1 > /tmp/cspcl-node1.log 2>&1 &
+nohup stdbuf -oL -eL env \
+  CSPCL_ASABR_ADAPTER_BIN="$CSPCL_ASABR_ADAPTER_BIN" \
+  CSPCL_ASABR_CONTACT_PLAN_PATH="$CSPCL_ASABR_CONTACT_PLAN_PATH" \
+  ./build/unibo-bp-cspcl 2 10 zmqhub 2002 /tmp/unibo-node2 > /tmp/cspcl-node2.log 2>&1 &
 
 sleep 1
 pgrep -fa 'unibo-bp-cspcl'
@@ -296,7 +337,7 @@ tail -f .uD3TN/unibo-bp.log
 | Start ZMQ broker     | `python3 $CSPCL_DIR/tools/zmqhub_broker.py -v`                                                  |
 | Start Unibo-BP node  | `$UNIBO_BP_BIN/unibo-bp start --daemon --dtn-admin dtn://X.dtn/ --ipn-admin ipn:X.0`            |
 | Configure DTN routes | `$UNIBO_BP_BIN/unibo-bp-admin routing static add --destination ipn:Y.Z --gateway ipn:Y.0`       |
-| Start CSPCL daemon   | `./build/unibo-bp-cspcl 1 10 zmqhub 2001 /tmp/unibo-node1`                                      |
+| Start CSPCL daemon   | `env CSPCL_ASABR_ADAPTER_BIN="$CSPCL_ASABR_ADAPTER_BIN" CSPCL_ASABR_CONTACT_PLAN_PATH="$CSPCL_ASABR_CONTACT_PLAN_PATH" ./build/unibo-bp-cspcl 1 10 zmqhub 2001 /tmp/unibo-node1` |
 | Send test bundle     | `$UNIBO_BP_BIN/unibo-bp-send --source ipn:1.55 --destination ipn:2.55 --payload-string 'Hello'` |
 | Receive bundle       | `$UNIBO_BP_BIN/unibo-bp-sink ipn:2.55`                                                          |
 | Check processes      | `pgrep -fa 'unibo-bp\|cspcl\|zmqhub'`                                                           |

--- a/rust-bindings/Cargo.lock
+++ b/rust-bindings/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "a_sabr"
+version = "0.1.0"
+dependencies = [
+ "derivative",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,7 +37,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -65,10 +74,17 @@ dependencies = [
 
 [[package]]
 name = "cspcl"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cspcl-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
+]
+
+[[package]]
+name = "cspcl-asabr-adapter"
+version = "0.1.0"
+dependencies = [
+ "a_sabr",
 ]
 
 [[package]]
@@ -85,6 +101,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79ff1cb8f13bd8e431ccc32369a9b8a64dce0eb4c7aaab0a8c2cc82e162ce492"
 dependencies = [
  "bindgen",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -149,7 +176,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -195,6 +222,12 @@ checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
@@ -253,7 +286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -310,6 +343,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +396,17 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -343,3 +430,9 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "3"
-members = ["cspcl", "cspcl-sys"]
+members = ["cspcl", "cspcl-sys", "asabr-adapter"]

--- a/rust-bindings/asabr-adapter/Cargo.toml
+++ b/rust-bindings/asabr-adapter/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "cspcl-asabr-adapter"
+version = "0.1.0"
+edition = "2024"
+description = "C ABI adapter that routes CSPCL requests through A-SABR"
+authors = ["cspcl contributors"]
+license = "MIT"
+repository = "https://github.com/d3tn/cspcl"
+
+[lib]
+crate-type = ["cdylib", "staticlib", "rlib"]
+name = "cspcl_asabr_adapter"
+
+[dependencies]
+a_sabr = { path = "../../../A-SABR" }

--- a/rust-bindings/asabr-adapter/src/bin/cspcl-asabr-adapter.rs
+++ b/rust-bindings/asabr-adapter/src/bin/cspcl-asabr-adapter.rs
@@ -1,7 +1,8 @@
 use std::env;
 
 use cspcl_asabr_adapter::{
-    cspcl_route_decision_status_t, cspcl_route_mode_t, cspcl_route_request_t, query_route,
+    RouteRequest, cspcl_route_decision_status_t, cspcl_route_mode_t, query_route,
+    set_contact_plan_path,
 };
 
 fn parse_list(value: Option<String>) -> Vec<u16> {
@@ -110,8 +111,9 @@ fn main() {
         eprintln!("missing contact plan path");
         std::process::exit(2);
     }
-    unsafe {
-        env::set_var("CSPCL_ASABR_CONTACT_PLAN_PATH", &contact_plan_path);
+    if let Err(err) = set_contact_plan_path(Some(contact_plan_path)) {
+        eprintln!("failed to configure contact plan path: {}", err as i32);
+        std::process::exit(2);
     }
 
     let source_node_id = source_node_id.unwrap_or_else(|| {
@@ -125,22 +127,14 @@ fn main() {
     }
     let excluded = parse_list(excluded_nodes);
 
-    let destination_storage = destinations;
-    let excluded_storage = excluded;
-    let request = cspcl_route_request_t {
+    let request = RouteRequest {
         source_node_id,
-        destination_node_ids: destination_storage.as_ptr(),
-        destination_count: destination_storage.len(),
+        destinations,
         bundle_priority,
         bundle_size,
         bundle_expiration,
         current_time,
-        excluded_node_ids: if excluded_storage.is_empty() {
-            std::ptr::null()
-        } else {
-            excluded_storage.as_ptr()
-        },
-        excluded_node_count: excluded_storage.len(),
+        excluded,
         timeout_ms,
     };
 

--- a/rust-bindings/asabr-adapter/src/bin/cspcl-asabr-adapter.rs
+++ b/rust-bindings/asabr-adapter/src/bin/cspcl-asabr-adapter.rs
@@ -1,0 +1,157 @@
+use std::env;
+
+use cspcl_asabr_adapter::{
+    cspcl_route_decision_status_t, cspcl_route_mode_t, cspcl_route_request_t, query_route,
+};
+
+fn parse_list(value: Option<String>) -> Vec<u16> {
+    value
+        .unwrap_or_default()
+        .split(',')
+        .filter_map(|entry| entry.trim().parse::<u16>().ok())
+        .collect()
+}
+
+fn usage(program: &str) -> ! {
+    eprintln!(
+        "Usage: {program} query --cp <path> --source <id> --dest <ids> [--excluded <ids>] [--priority <n>] [--size <bytes>] [--expiration <t>] [--current-time <t>] [--timeout-ms <ms>]"
+    );
+    std::process::exit(2);
+}
+
+fn print_decision(decision: &cspcl_asabr_adapter::RouteDecision) {
+    let status = match decision.decision_status {
+        cspcl_route_decision_status_t::CSPCL_ROUTE_DECISION_FOUND => "FOUND",
+        cspcl_route_decision_status_t::CSPCL_ROUTE_DECISION_NO_ROUTE => "NO_ROUTE",
+        cspcl_route_decision_status_t::CSPCL_ROUTE_DECISION_PROVIDER_ERROR => "PROVIDER_ERROR",
+        cspcl_route_decision_status_t::CSPCL_ROUTE_DECISION_TIMEOUT => "TIMEOUT",
+    };
+
+    let mode = match decision.mode {
+        cspcl_route_mode_t::CSPCL_ROUTE_MODE_NONE => "NONE",
+        cspcl_route_mode_t::CSPCL_ROUTE_MODE_UNICAST => "UNICAST",
+        cspcl_route_mode_t::CSPCL_ROUTE_MODE_MULTICAST => "MULTICAST",
+    };
+
+    println!("STATUS={status}");
+    println!("MODE={mode}");
+    println!("DIAG={}", decision.diagnostic.to_string_lossy());
+    for hop in &decision.next_hops {
+        println!(
+            "HOP={},{},{}",
+            hop.next_hop_node_id, hop.contact_identifier, hop.estimated_arrival_time
+        );
+    }
+}
+
+fn main() {
+    let mut args = env::args();
+    let program = args
+        .next()
+        .unwrap_or_else(|| "cspcl-asabr-adapter".to_string());
+    let command = args.next().unwrap_or_else(|| usage(&program));
+    if command != "query" {
+        usage(&program);
+    }
+
+    let mut contact_plan_path = None::<String>;
+    let mut source_node_id = None::<u16>;
+    let mut destination_nodes = None::<String>;
+    let mut excluded_nodes = None::<String>;
+    let mut bundle_priority = 0i8;
+    let mut bundle_size = 1.0f64;
+    let mut bundle_expiration = 0.0f64;
+    let mut current_time = 0.0f64;
+    let mut timeout_ms = 0u32;
+
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--cp" => contact_plan_path = args.next(),
+            "--source" => source_node_id = args.next().and_then(|value| value.parse().ok()),
+            "--dest" => destination_nodes = args.next(),
+            "--excluded" => excluded_nodes = args.next(),
+            "--priority" => {
+                bundle_priority = args
+                    .next()
+                    .and_then(|value| value.parse().ok())
+                    .unwrap_or(0)
+            }
+            "--size" => {
+                bundle_size = args
+                    .next()
+                    .and_then(|value| value.parse().ok())
+                    .unwrap_or(1.0)
+            }
+            "--expiration" => {
+                bundle_expiration = args
+                    .next()
+                    .and_then(|value| value.parse().ok())
+                    .unwrap_or(0.0)
+            }
+            "--current-time" => {
+                current_time = args
+                    .next()
+                    .and_then(|value| value.parse().ok())
+                    .unwrap_or(0.0)
+            }
+            "--timeout-ms" => {
+                timeout_ms = args
+                    .next()
+                    .and_then(|value| value.parse().ok())
+                    .unwrap_or(0)
+            }
+            _ => usage(&program),
+        }
+    }
+
+    let contact_plan_path = contact_plan_path
+        .unwrap_or_else(|| env::var("CSPCL_ASABR_CONTACT_PLAN_PATH").unwrap_or_default());
+    if contact_plan_path.is_empty() {
+        eprintln!("missing contact plan path");
+        std::process::exit(2);
+    }
+    unsafe {
+        env::set_var("CSPCL_ASABR_CONTACT_PLAN_PATH", &contact_plan_path);
+    }
+
+    let source_node_id = source_node_id.unwrap_or_else(|| {
+        eprintln!("missing source node id");
+        std::process::exit(2);
+    });
+    let destinations = parse_list(destination_nodes);
+    if destinations.is_empty() {
+        eprintln!("missing destination list");
+        std::process::exit(2);
+    }
+    let excluded = parse_list(excluded_nodes);
+
+    let destination_storage = destinations;
+    let excluded_storage = excluded;
+    let request = cspcl_route_request_t {
+        source_node_id,
+        destination_node_ids: destination_storage.as_ptr(),
+        destination_count: destination_storage.len(),
+        bundle_priority,
+        bundle_size,
+        bundle_expiration,
+        current_time,
+        excluded_node_ids: if excluded_storage.is_empty() {
+            std::ptr::null()
+        } else {
+            excluded_storage.as_ptr()
+        },
+        excluded_node_count: excluded_storage.len(),
+        timeout_ms,
+    };
+
+    match query_route(&request) {
+        Ok(decision) => {
+            print_decision(&decision);
+            std::process::exit(0);
+        }
+        Err(err) => {
+            eprintln!("routing failed: {}", err as i32);
+            std::process::exit(1);
+        }
+    }
+}

--- a/rust-bindings/asabr-adapter/src/ffi.rs
+++ b/rust-bindings/asabr-adapter/src/ffi.rs
@@ -1,0 +1,44 @@
+use std::ffi::c_void;
+
+use crate::query::query_route;
+use crate::routing::RouteDecision;
+use crate::state::{reset_state, with_state_mut};
+use crate::types::{cspcl_route_error_t, cspcl_route_provider_output_t, cspcl_route_request_t};
+
+fn publish_decision(
+    decision: RouteDecision,
+    output: &mut cspcl_route_provider_output_t,
+) -> cspcl_route_error_t {
+    with_state_mut(|state| {
+        state.next_hops = decision.next_hops;
+        state.diagnostic = decision.diagnostic;
+        output.decision_status = decision.decision_status;
+        output.mode = decision.mode;
+        output.next_hops = state.next_hops.as_ptr();
+        output.next_hop_count = state.next_hops.len();
+        output.diagnostic = state.diagnostic.as_ptr();
+    });
+
+    cspcl_route_error_t::CSPCL_ROUTE_OK
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn cspcl_asabr_route_provider(
+    request: *const cspcl_route_request_t,
+    output: *mut cspcl_route_provider_output_t,
+    _user_ctx: *mut c_void,
+) -> cspcl_route_error_t {
+    if request.is_null() || output.is_null() {
+        return cspcl_route_error_t::CSPCL_ROUTE_ERR_INVALID_PARAM;
+    }
+
+    match query_route(unsafe { &*request }) {
+        Ok(decision) => publish_decision(decision, unsafe { &mut *output }),
+        Err(err) => err,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn cspcl_asabr_route_provider_reset() {
+    reset_state();
+}

--- a/rust-bindings/asabr-adapter/src/ffi.rs
+++ b/rust-bindings/asabr-adapter/src/ffi.rs
@@ -1,9 +1,48 @@
 use std::ffi::c_void;
+use std::mem;
+use std::ptr::NonNull;
 
 use crate::query::query_route;
-use crate::routing::RouteDecision;
+use crate::routing::{RouteDecision, RouteRequest};
 use crate::state::{reset_state, with_state_mut};
 use crate::types::{cspcl_route_error_t, cspcl_route_provider_output_t, cspcl_route_request_t};
+
+fn validate_slice_len<T>(count: usize) -> bool {
+    count <= (isize::MAX as usize) / mem::size_of::<T>()
+}
+
+fn copy_nodes(ptr: *const u16, count: usize) -> Result<Vec<u16>, cspcl_route_error_t> {
+    if count == 0 {
+        return Ok(Vec::new());
+    }
+
+    if ptr.is_null() || !validate_slice_len::<u16>(count) {
+        return Err(cspcl_route_error_t::CSPCL_ROUTE_ERR_INVALID_PARAM);
+    }
+
+    // SAFETY: pointer is non-null, length was validated, and caller provides FFI buffer validity.
+    Ok(unsafe { std::slice::from_raw_parts(ptr, count) }.to_vec())
+}
+
+fn request_from_ffi(request: &cspcl_route_request_t) -> Result<RouteRequest, cspcl_route_error_t> {
+    let destinations = copy_nodes(request.destination_node_ids, request.destination_count)?;
+    if destinations.is_empty() {
+        return Err(cspcl_route_error_t::CSPCL_ROUTE_ERR_INVALID_PARAM);
+    }
+
+    let excluded = copy_nodes(request.excluded_node_ids, request.excluded_node_count)?;
+
+    Ok(RouteRequest {
+        source_node_id: request.source_node_id,
+        destinations,
+        bundle_priority: request.bundle_priority,
+        bundle_size: request.bundle_size,
+        bundle_expiration: request.bundle_expiration,
+        current_time: request.current_time,
+        excluded,
+        timeout_ms: request.timeout_ms,
+    })
+}
 
 fn publish_decision(
     decision: RouteDecision,
@@ -28,12 +67,29 @@ pub extern "C" fn cspcl_asabr_route_provider(
     output: *mut cspcl_route_provider_output_t,
     _user_ctx: *mut c_void,
 ) -> cspcl_route_error_t {
-    if request.is_null() || output.is_null() {
-        return cspcl_route_error_t::CSPCL_ROUTE_ERR_INVALID_PARAM;
-    }
+    let request = match NonNull::new(request as *mut cspcl_route_request_t) {
+        Some(request_ptr) => {
+            // SAFETY: NonNull guarantees a non-null pointer.
+            unsafe { request_ptr.as_ref() }
+        }
+        None => return cspcl_route_error_t::CSPCL_ROUTE_ERR_INVALID_PARAM,
+    };
 
-    match query_route(unsafe { &*request }) {
-        Ok(decision) => publish_decision(decision, unsafe { &mut *output }),
+    let output = match NonNull::new(output) {
+        Some(mut output_ptr) => {
+            // SAFETY: NonNull guarantees a non-null pointer.
+            unsafe { output_ptr.as_mut() }
+        }
+        None => return cspcl_route_error_t::CSPCL_ROUTE_ERR_INVALID_PARAM,
+    };
+
+    let request = match request_from_ffi(request) {
+        Ok(request) => request,
+        Err(err) => return err,
+    };
+
+    match query_route(&request) {
+        Ok(decision) => publish_decision(decision, output),
         Err(err) => err,
     }
 }

--- a/rust-bindings/asabr-adapter/src/lib.rs
+++ b/rust-bindings/asabr-adapter/src/lib.rs
@@ -1,0 +1,13 @@
+mod ffi;
+pub mod query;
+mod routing;
+mod state;
+mod types;
+
+pub use ffi::{cspcl_asabr_route_provider, cspcl_asabr_route_provider_reset};
+pub use query::query_route;
+pub use routing::RouteDecision;
+pub use types::{
+    cspcl_route_decision_status_t, cspcl_route_error_t, cspcl_route_mode_t, cspcl_route_next_hop_t,
+    cspcl_route_provider_output_t, cspcl_route_request_t,
+};

--- a/rust-bindings/asabr-adapter/src/lib.rs
+++ b/rust-bindings/asabr-adapter/src/lib.rs
@@ -5,8 +5,8 @@ mod state;
 mod types;
 
 pub use ffi::{cspcl_asabr_route_provider, cspcl_asabr_route_provider_reset};
-pub use query::query_route;
-pub use routing::RouteDecision;
+pub use query::{query_route, set_contact_plan_path};
+pub use routing::{RouteDecision, RouteRequest};
 pub use types::{
     cspcl_route_decision_status_t, cspcl_route_error_t, cspcl_route_mode_t, cspcl_route_next_hop_t,
     cspcl_route_provider_output_t, cspcl_route_request_t,

--- a/rust-bindings/asabr-adapter/src/query.rs
+++ b/rust-bindings/asabr-adapter/src/query.rs
@@ -1,0 +1,9 @@
+use crate::routing::{RouteDecision, decide_route};
+use crate::state::{init_state, with_state_mut};
+use crate::types::{cspcl_route_error_t, cspcl_route_request_t};
+
+pub fn query_route(request: &cspcl_route_request_t) -> Result<RouteDecision, cspcl_route_error_t> {
+    init_state()?;
+
+    with_state_mut(|state| decide_route(state, request))
+}

--- a/rust-bindings/asabr-adapter/src/query.rs
+++ b/rust-bindings/asabr-adapter/src/query.rs
@@ -1,9 +1,13 @@
-use crate::routing::{RouteDecision, decide_route};
-use crate::state::{init_state, with_state_mut};
-use crate::types::{cspcl_route_error_t, cspcl_route_request_t};
+use crate::routing::{RouteDecision, RouteRequest, decide_route};
+use crate::state::{init_state, set_contact_plan_path as set_cp_path, with_state_mut};
+use crate::types::cspcl_route_error_t;
 
-pub fn query_route(request: &cspcl_route_request_t) -> Result<RouteDecision, cspcl_route_error_t> {
+pub fn query_route(request: &RouteRequest) -> Result<RouteDecision, cspcl_route_error_t> {
     init_state()?;
 
     with_state_mut(|state| decide_route(state, request))
+}
+
+pub fn set_contact_plan_path(path: Option<String>) -> Result<(), cspcl_route_error_t> {
+    set_cp_path(path)
 }

--- a/rust-bindings/asabr-adapter/src/routing.rs
+++ b/rust-bindings/asabr-adapter/src/routing.rs
@@ -1,0 +1,146 @@
+use std::ffi::CString;
+
+use a_sabr::bundle::Bundle;
+
+use crate::state::AdapterState;
+use crate::types::{
+    cspcl_route_decision_status_t, cspcl_route_error_t, cspcl_route_mode_t, cspcl_route_next_hop_t,
+    cspcl_route_request_t,
+};
+
+pub struct RouteDecision {
+    pub decision_status: cspcl_route_decision_status_t,
+    pub mode: cspcl_route_mode_t,
+    pub next_hops: Vec<cspcl_route_next_hop_t>,
+    pub diagnostic: CString,
+}
+
+pub(crate) fn contact_identifier(tx_node: u16, rx_node: u16, start: f64, end: f64) -> u64 {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in tx_node.to_le_bytes() {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    for byte in rx_node.to_le_bytes() {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    for byte in start.to_bits().to_le_bytes() {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    for byte in end.to_bits().to_le_bytes() {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+pub(crate) fn decide_route(
+    state: &mut AdapterState,
+    request: &cspcl_route_request_t,
+) -> Result<RouteDecision, cspcl_route_error_t> {
+    if request.destination_count == 0 || request.destination_node_ids.is_null() {
+        return Err(cspcl_route_error_t::CSPCL_ROUTE_ERR_INVALID_PARAM);
+    }
+
+    let destinations = unsafe {
+        std::slice::from_raw_parts(request.destination_node_ids, request.destination_count)
+    };
+    let excluded = if request.excluded_node_count == 0 || request.excluded_node_ids.is_null() {
+        Vec::new()
+    } else {
+        unsafe {
+            std::slice::from_raw_parts(request.excluded_node_ids, request.excluded_node_count)
+        }
+        .to_vec()
+    };
+
+    let bundle = Bundle {
+        source: request.source_node_id,
+        destinations: destinations.to_vec(),
+        priority: request.bundle_priority,
+        size: request.bundle_size,
+        expiration: request.bundle_expiration,
+    };
+
+    let routing_result = state.router.route(
+        request.source_node_id,
+        &bundle,
+        request.current_time,
+        &excluded,
+    );
+
+    let maybe_output = match routing_result {
+        Ok(Some(output)) => output,
+        Ok(None) => {
+            return Ok(RouteDecision {
+                decision_status: cspcl_route_decision_status_t::CSPCL_ROUTE_DECISION_NO_ROUTE,
+                mode: cspcl_route_mode_t::CSPCL_ROUTE_MODE_NONE,
+                next_hops: Vec::new(),
+                diagnostic: CString::new("no-route").unwrap(),
+            });
+        }
+        Err(_) => {
+            return Ok(RouteDecision {
+                decision_status: cspcl_route_decision_status_t::CSPCL_ROUTE_DECISION_PROVIDER_ERROR,
+                mode: cspcl_route_mode_t::CSPCL_ROUTE_MODE_NONE,
+                next_hops: Vec::new(),
+                diagnostic: CString::new("provider-error").unwrap(),
+            });
+        }
+    };
+
+    let mut next_hops = Vec::new();
+
+    for (_, (contact_rc, routes)) in maybe_output.first_hops.iter() {
+        let contact = contact_rc.borrow();
+        let first_route = routes.first().expect("route list cannot be empty");
+        let route_stage = first_route.borrow();
+        let next_hop = cspcl_route_next_hop_t {
+            next_hop_node_id: contact.get_rx_node(),
+            contact_identifier: contact_identifier(
+                contact.get_tx_node(),
+                contact.get_rx_node(),
+                contact.info.start,
+                contact.info.end,
+            ),
+            estimated_arrival_time: route_stage.at_time,
+        };
+        next_hops.push(next_hop);
+    }
+
+    if next_hops.is_empty() {
+        return Ok(RouteDecision {
+            decision_status: cspcl_route_decision_status_t::CSPCL_ROUTE_DECISION_NO_ROUTE,
+            mode: cspcl_route_mode_t::CSPCL_ROUTE_MODE_NONE,
+            next_hops,
+            diagnostic: CString::new("no-route").unwrap(),
+        });
+    }
+
+    let decision_mode = if next_hops.len() > 1 || request.destination_count > 1 {
+        cspcl_route_mode_t::CSPCL_ROUTE_MODE_MULTICAST
+    } else {
+        cspcl_route_mode_t::CSPCL_ROUTE_MODE_UNICAST
+    };
+
+    Ok(RouteDecision {
+        decision_status: cspcl_route_decision_status_t::CSPCL_ROUTE_DECISION_FOUND,
+        mode: decision_mode,
+        next_hops,
+        diagnostic: CString::new("asabr-route-found").unwrap(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::contact_identifier;
+
+    #[test]
+    fn contact_identifier_is_stable() {
+        let a = contact_identifier(1, 2, 10.0, 20.0);
+        let b = contact_identifier(1, 2, 10.0, 20.0);
+        assert_eq!(a, b);
+    }
+}

--- a/rust-bindings/asabr-adapter/src/routing.rs
+++ b/rust-bindings/asabr-adapter/src/routing.rs
@@ -5,8 +5,18 @@ use a_sabr::bundle::Bundle;
 use crate::state::AdapterState;
 use crate::types::{
     cspcl_route_decision_status_t, cspcl_route_error_t, cspcl_route_mode_t, cspcl_route_next_hop_t,
-    cspcl_route_request_t,
 };
+
+pub struct RouteRequest {
+    pub source_node_id: u16,
+    pub destinations: Vec<u16>,
+    pub bundle_priority: i8,
+    pub bundle_size: f64,
+    pub bundle_expiration: f64,
+    pub current_time: f64,
+    pub excluded: Vec<u16>,
+    pub timeout_ms: u32,
+}
 
 pub struct RouteDecision {
     pub decision_status: cspcl_route_decision_status_t,
@@ -38,27 +48,15 @@ pub(crate) fn contact_identifier(tx_node: u16, rx_node: u16, start: f64, end: f6
 
 pub(crate) fn decide_route(
     state: &mut AdapterState,
-    request: &cspcl_route_request_t,
+    request: &RouteRequest,
 ) -> Result<RouteDecision, cspcl_route_error_t> {
-    if request.destination_count == 0 || request.destination_node_ids.is_null() {
+    if request.destinations.is_empty() {
         return Err(cspcl_route_error_t::CSPCL_ROUTE_ERR_INVALID_PARAM);
     }
 
-    let destinations = unsafe {
-        std::slice::from_raw_parts(request.destination_node_ids, request.destination_count)
-    };
-    let excluded = if request.excluded_node_count == 0 || request.excluded_node_ids.is_null() {
-        Vec::new()
-    } else {
-        unsafe {
-            std::slice::from_raw_parts(request.excluded_node_ids, request.excluded_node_count)
-        }
-        .to_vec()
-    };
-
     let bundle = Bundle {
         source: request.source_node_id,
-        destinations: destinations.to_vec(),
+        destinations: request.destinations.clone(),
         priority: request.bundle_priority,
         size: request.bundle_size,
         expiration: request.bundle_expiration,
@@ -68,7 +66,7 @@ pub(crate) fn decide_route(
         request.source_node_id,
         &bundle,
         request.current_time,
-        &excluded,
+        &request.excluded,
     );
 
     let maybe_output = match routing_result {
@@ -119,7 +117,7 @@ pub(crate) fn decide_route(
         });
     }
 
-    let decision_mode = if next_hops.len() > 1 || request.destination_count > 1 {
+    let decision_mode = if next_hops.len() > 1 || request.destinations.len() > 1 {
         cspcl_route_mode_t::CSPCL_ROUTE_MODE_MULTICAST
     } else {
         cspcl_route_mode_t::CSPCL_ROUTE_MODE_UNICAST

--- a/rust-bindings/asabr-adapter/src/state.rs
+++ b/rust-bindings/asabr-adapter/src/state.rs
@@ -24,6 +24,7 @@ pub(crate) struct AdapterState {
 
 thread_local! {
     static STATE: RefCell<Option<AdapterState>> = const { RefCell::new(None) };
+    static CONTACT_PLAN_PATH_OVERRIDE: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
 fn get_env_string(name: &str) -> Option<String> {
@@ -34,8 +35,27 @@ fn get_env_string(name: &str) -> Option<String> {
 }
 
 fn get_default_contact_plan_path() -> Result<String, cspcl_route_error_t> {
+    let override_path = CONTACT_PLAN_PATH_OVERRIDE.with(|path_cell| path_cell.borrow().clone());
+    if let Some(path) = override_path {
+        if !path.trim().is_empty() {
+            return Ok(path);
+        }
+    }
+
     get_env_string("CSPCL_ASABR_CONTACT_PLAN_PATH")
         .ok_or(cspcl_route_error_t::CSPCL_ROUTE_ERR_PROVIDER_FAILED)
+}
+
+pub(crate) fn set_contact_plan_path(path: Option<String>) -> Result<(), cspcl_route_error_t> {
+    if matches!(path.as_deref(), Some(raw) if raw.trim().is_empty()) {
+        return Err(cspcl_route_error_t::CSPCL_ROUTE_ERR_INVALID_PARAM);
+    }
+
+    CONTACT_PLAN_PATH_OVERRIDE.with(|path_cell| {
+        *path_cell.borrow_mut() = path;
+    });
+    reset_state();
+    Ok(())
 }
 
 fn build_contact_dispatch() -> ContactMarkerMap<'static> {

--- a/rust-bindings/asabr-adapter/src/state.rs
+++ b/rust-bindings/asabr-adapter/src/state.rs
@@ -1,0 +1,107 @@
+use std::cell::RefCell;
+use std::env;
+use std::ffi::CString;
+use std::rc::Rc;
+
+use a_sabr::contact_manager::{
+    ContactManager,
+    legacy::{eto::ETOManager, evl::EVLManager, qd::QDManager},
+    segmentation::seg::SegmentationManager,
+};
+use a_sabr::contact_plan::{asabr_file_lexer::FileLexer, from_asabr_lexer::ASABRContactPlan};
+use a_sabr::node_manager::none::NoManagement;
+use a_sabr::parsing::{ContactMarkerMap, coerce_cm};
+use a_sabr::route_storage::cache::TreeCache;
+use a_sabr::routing::{Router, aliases::SpsnHybridParenting};
+
+use crate::types::{cspcl_route_error_t, cspcl_route_next_hop_t};
+
+pub(crate) struct AdapterState {
+    pub(crate) router: Box<dyn Router<NoManagement, Box<dyn ContactManager>>>,
+    pub(crate) next_hops: Vec<cspcl_route_next_hop_t>,
+    pub(crate) diagnostic: CString,
+}
+
+thread_local! {
+    static STATE: RefCell<Option<AdapterState>> = const { RefCell::new(None) };
+}
+
+fn get_env_string(name: &str) -> Option<String> {
+    match env::var(name) {
+        Ok(value) if !value.trim().is_empty() => Some(value),
+        _ => None,
+    }
+}
+
+fn get_default_contact_plan_path() -> Result<String, cspcl_route_error_t> {
+    get_env_string("CSPCL_ASABR_CONTACT_PLAN_PATH")
+        .ok_or(cspcl_route_error_t::CSPCL_ROUTE_ERR_PROVIDER_FAILED)
+}
+
+fn build_contact_dispatch() -> ContactMarkerMap<'static> {
+    let mut contact_dispatch = ContactMarkerMap::new();
+    contact_dispatch.add("evl", coerce_cm::<EVLManager>);
+    contact_dispatch.add("qd", coerce_cm::<QDManager>);
+    contact_dispatch.add("eto", coerce_cm::<ETOManager>);
+    contact_dispatch.add("seg", coerce_cm::<SegmentationManager>);
+    contact_dispatch
+}
+
+fn load_router()
+-> Result<Box<dyn Router<NoManagement, Box<dyn ContactManager>>>, cspcl_route_error_t> {
+    let cp_path = get_default_contact_plan_path()?;
+    let mut lexer = FileLexer::new(&cp_path)
+        .map_err(|_| cspcl_route_error_t::CSPCL_ROUTE_ERR_PROVIDER_FAILED)?;
+    let contact_dispatch = build_contact_dispatch();
+
+    let contact_plan = ASABRContactPlan::parse::<NoManagement, Box<dyn ContactManager>>(
+        &mut lexer,
+        None,
+        Some(&contact_dispatch),
+    )
+    .map_err(|_| cspcl_route_error_t::CSPCL_ROUTE_ERR_PROVIDER_FAILED)?;
+
+    let table = Rc::new(RefCell::new(TreeCache::new(true, false, 10)));
+    let router = SpsnHybridParenting::<NoManagement, Box<dyn ContactManager>>::new(
+        contact_plan,
+        table,
+        false,
+    )
+    .map_err(|_| cspcl_route_error_t::CSPCL_ROUTE_ERR_PROVIDER_FAILED)?;
+
+    Ok(Box::new(router))
+}
+
+pub(crate) fn init_state() -> Result<(), cspcl_route_error_t> {
+    STATE.with(|state_cell| {
+        let mut state_ref = state_cell.borrow_mut();
+        if state_ref.is_some() {
+            return Ok(());
+        }
+
+        let router = load_router()?;
+        *state_ref = Some(AdapterState {
+            router,
+            next_hops: Vec::new(),
+            diagnostic: CString::new("asabr-adapter-initialized").unwrap(),
+        });
+        Ok(())
+    })
+}
+
+pub(crate) fn with_state_mut<F, R>(f: F) -> R
+where
+    F: FnOnce(&mut AdapterState) -> R,
+{
+    STATE.with(|state_cell| {
+        let mut state_ref = state_cell.borrow_mut();
+        let state = state_ref.as_mut().expect("adapter state initialized");
+        f(state)
+    })
+}
+
+pub(crate) fn reset_state() {
+    STATE.with(|state_cell| {
+        *state_cell.borrow_mut() = None;
+    });
+}

--- a/rust-bindings/asabr-adapter/src/types.rs
+++ b/rust-bindings/asabr-adapter/src/types.rs
@@ -1,0 +1,64 @@
+#![allow(non_camel_case_types)]
+
+use std::os::raw::c_char;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum cspcl_route_mode_t {
+    CSPCL_ROUTE_MODE_NONE = 0,
+    CSPCL_ROUTE_MODE_UNICAST,
+    CSPCL_ROUTE_MODE_MULTICAST,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum cspcl_route_decision_status_t {
+    CSPCL_ROUTE_DECISION_FOUND = 0,
+    CSPCL_ROUTE_DECISION_NO_ROUTE,
+    CSPCL_ROUTE_DECISION_PROVIDER_ERROR,
+    CSPCL_ROUTE_DECISION_TIMEOUT,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum cspcl_route_error_t {
+    CSPCL_ROUTE_OK = 0,
+    CSPCL_ROUTE_ERR_INVALID_PARAM,
+    CSPCL_ROUTE_ERR_NOT_INITIALIZED,
+    CSPCL_ROUTE_ERR_ALREADY_INITIALIZED,
+    CSPCL_ROUTE_ERR_NO_PROVIDER,
+    CSPCL_ROUTE_ERR_PROVIDER_FAILED,
+    CSPCL_ROUTE_ERR_NO_MEMORY,
+    CSPCL_ROUTE_ERR_INTERNAL,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct cspcl_route_next_hop_t {
+    pub next_hop_node_id: u16,
+    pub contact_identifier: u64,
+    pub estimated_arrival_time: f64,
+}
+
+#[repr(C)]
+pub struct cspcl_route_request_t {
+    pub source_node_id: u16,
+    pub destination_node_ids: *const u16,
+    pub destination_count: usize,
+    pub bundle_priority: i8,
+    pub bundle_size: f64,
+    pub bundle_expiration: f64,
+    pub current_time: f64,
+    pub excluded_node_ids: *const u16,
+    pub excluded_node_count: usize,
+    pub timeout_ms: u32,
+}
+
+#[repr(C)]
+pub struct cspcl_route_provider_output_t {
+    pub decision_status: cspcl_route_decision_status_t,
+    pub mode: cspcl_route_mode_t,
+    pub next_hops: *const cspcl_route_next_hop_t,
+    pub next_hop_count: usize,
+    pub diagnostic: *const c_char,
+}

--- a/rust-bindings/cspcl-sys/build.rs
+++ b/rust-bindings/cspcl-sys/build.rs
@@ -5,23 +5,15 @@ fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let manifest_path = PathBuf::from(&manifest_dir);
 
-    // When published to crates.io, the C source files are included in the crate root
-    // Check cspcl-sys/src first (where they'll be when published)
+    // Canonical C sources for cspcl-sys are vendored in c_src.
     let src_in_crate = manifest_path.join("c_src");
-
-    // Otherwise look in workspace (local development)
-    let workspace_root = manifest_path.parent().unwrap().parent().unwrap();
-    let src_in_workspace = workspace_root.join("src");
 
     let src_dir = if src_in_crate.exists() {
         src_in_crate
-    } else if src_in_workspace.exists() {
-        src_in_workspace
     } else {
         panic!(
-            "C source directory not found. Looked in:\n  {}\n  {}",
-            src_in_crate.display(),
-            src_in_workspace.display()
+            "C source directory not found. Expected:\n  {}",
+            src_in_crate.display()
         );
     };
 

--- a/src/cspcl.c
+++ b/src/cspcl.c
@@ -23,7 +23,9 @@
 #include <csp/csp.h>
 /* libcsp headers for direct CSP stack control */
 #include <csp/csp_rtable.h>
+#ifdef CSP_HAVE_LIBZMQ
 #include <csp/interfaces/csp_if_zmqhub.h>
+#endif
 /* CAN interface support - requires libcsp built with CAN driver */
 #ifdef CSP_HAVE_LIBSOCKETCAN
 #include <csp/drivers/can_socketcan.h>
@@ -197,12 +199,17 @@ cspcl_error_t cspcl_init(cspcl_t *cspcl) {
     /* Initialize the selected interface */
     switch (cspcl->iface_type) {
     case CSP_IFACE_ZMQHUB:
+#ifdef CSP_HAVE_LIBZMQ
       ret = csp_zmqhub_init(cspcl->local_addr, cspcl->zmqhub_addr, 0,
                             &cspcl->active_iface);
       if (ret != CSP_ERR_NONE) {
         cspcl_release_conn_pool(cspcl);
         return CSPCL_ERR_CSP_ZMQHUB_INIT;
       }
+#else
+      cspcl_release_conn_pool(cspcl);
+      return CSPCL_ERR_CSP_ZMQHUB_INIT;
+#endif
       break;
 
     case CSP_IFACE_CAN:

--- a/src/cspcl.c
+++ b/src/cspcl.c
@@ -70,8 +70,7 @@ static csp_conn_t *cspcl_pool_get_or_create_locked(cspcl_conn_pool_t *pool,
 #ifndef FREERTOS
       /* Age-based invalidation (disabled when max_conn_age_ms == 0) */
       if (pool->max_conn_age_ms > 0) {
-        uint32_t age_s =
-            (uint32_t)(time(NULL) - pool->entries[i].connected_at);
+        uint32_t age_s = (uint32_t)(time(NULL) - pool->entries[i].connected_at);
         if (age_s > pool->max_conn_age_ms / 1000u) {
           csp_close(pool->entries[i].conn);
           pool->entries[i].conn = NULL;
@@ -289,15 +288,18 @@ cspcl_error_t cspcl_conn_pool_init(cspcl_conn_pool_t *pool) {
   if (max_age_env != NULL) {
     char *endptr;
     long max_age_val = strtol(max_age_env, &endptr, 10);
-    
-    /* Validate that the entire string was consumed and value is in valid range */
-    if (*endptr == '\0' && max_age_val >= 0 && max_age_val <= (long)UINT32_MAX) {
+    /* Validate that the entire string was consumed and value is in valid range
+     */
+    if (*endptr == '\0' && max_age_val >= 0 &&
+        max_age_val <= (long)UINT32_MAX) {
       pool->max_conn_age_ms = (uint32_t)max_age_val;
-      CSPCL_DEBUG("Connection pool max age set to %u ms from CSPCL_MAX_CONN_AGE_MS", 
-                  pool->max_conn_age_ms);
+      CSPCL_LOG(
+          "Connection pool max age set to %u ms from CSPCL_MAX_CONN_AGE_MS",
+          pool->max_conn_age_ms);
     } else {
-      CSPCL_WARN("Invalid CSPCL_MAX_CONN_AGE_MS value '%s', ignoring (must be 0-%u)", 
-                 max_age_env, UINT32_MAX);
+      CSPCL_LOG(
+          "Invalid CSPCL_MAX_CONN_AGE_MS value '%s', ignoring (must be 0-%u)",
+          max_age_env, UINT32_MAX);
     }
   }
 

--- a/src/cspcl.h
+++ b/src/cspcl.h
@@ -29,7 +29,9 @@
 #include <csp/csp_types.h>
 /* libcsp headers for direct CSP stack control */
 #include <csp/csp_rtable.h>
+#ifdef CSP_HAVE_LIBZMQ
 #include <csp/interfaces/csp_if_zmqhub.h>
+#endif
 /* CAN interface support - requires libcsp built with CAN driver */
 #ifdef CSP_HAVE_LIBSOCKETCAN
 #include <csp/drivers/can_socketcan.h>
@@ -91,7 +93,7 @@ typedef enum {
   CSPCL_ERR_CSP_CAN_INIT,          /**< CAN interface init failed */
   CSPCL_ERR_CSP_CAN_NOT_SUPPORTED, /**< CAN support not compiled in */
   CSPCL_ERR_CSP_ROUTER,            /**< CSP router task start failed */
-  CSPCL_ERR_POOL_FULL              /**< Connection pool full, LRU eviction was forced */
+  CSPCL_ERR_POOL_FULL /**< Connection pool full, LRU eviction was forced */
 } cspcl_error_t;
 
 enum csp_iface_type {

--- a/src/cspcl_asabr_process_provider.c
+++ b/src/cspcl_asabr_process_provider.c
@@ -1,0 +1,482 @@
+#include "cspcl_asabr_process_provider.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef FREERTOS
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+typedef struct {
+  cspcl_asabr_process_provider_t *provider;
+} cspcl_asabr_process_provider_ctx_t;
+
+static char *cspcl_strdup_safe(const char *value) {
+  size_t length;
+  char *copy;
+
+  if (value == NULL || value[0] == '\0') {
+    return NULL;
+  }
+
+  length = strlen(value);
+  copy = (char *)malloc(length + 1);
+  if (copy == NULL) {
+    return NULL;
+  }
+
+  memcpy(copy, value, length + 1);
+  return copy;
+}
+
+static const char *cspcl_pick_config_value(const char *explicit_value,
+                                           const char *env_name) {
+  const char *env_value;
+
+  if (explicit_value != NULL && explicit_value[0] != '\0') {
+    return explicit_value;
+  }
+
+  env_value = getenv(env_name);
+  if (env_value != NULL && env_value[0] != '\0') {
+    return env_value;
+  }
+
+  return NULL;
+}
+
+static void
+cspcl_provider_reset_result(cspcl_asabr_process_provider_t *provider) {
+  if (provider == NULL) {
+    return;
+  }
+
+  provider->next_hop_count = 0;
+  provider->mode = CSPCL_ROUTE_MODE_NONE;
+  provider->decision_status = CSPCL_ROUTE_DECISION_PROVIDER_ERROR;
+  provider->diagnostic[0] = '\0';
+}
+
+static cspcl_route_error_t
+cspcl_provider_ensure_capacity(cspcl_asabr_process_provider_t *provider,
+                               size_t required_count) {
+  cspcl_route_next_hop_t *next_hops;
+  size_t new_capacity;
+
+  if (provider->next_hop_capacity >= required_count) {
+    return CSPCL_ROUTE_OK;
+  }
+
+  new_capacity =
+      provider->next_hop_capacity == 0 ? 4 : provider->next_hop_capacity;
+  while (new_capacity < required_count) {
+    new_capacity *= 2;
+  }
+
+  next_hops = (cspcl_route_next_hop_t *)realloc(
+      provider->next_hops, new_capacity * sizeof(cspcl_route_next_hop_t));
+  if (next_hops == NULL) {
+    return CSPCL_ROUTE_ERR_NO_MEMORY;
+  }
+
+  provider->next_hops = next_hops;
+  provider->next_hop_capacity = new_capacity;
+  return CSPCL_ROUTE_OK;
+}
+
+static cspcl_route_error_t cspcl_provider_join_u16_list(const uint16_t *values,
+                                                        size_t count,
+                                                        char **out_text) {
+  size_t buffer_size = 1;
+  char *buffer;
+  size_t offset = 0;
+
+  if (values == NULL || count == 0) {
+    *out_text = (char *)malloc(1);
+    if (*out_text == NULL) {
+      return CSPCL_ROUTE_ERR_NO_MEMORY;
+    }
+    (*out_text)[0] = '\0';
+    return CSPCL_ROUTE_OK;
+  }
+
+  for (size_t i = 0; i < count; i++) {
+    char temp[32];
+    int written = snprintf(temp, sizeof(temp), "%u", (unsigned)values[i]);
+    if (written < 0) {
+      return CSPCL_ROUTE_ERR_INTERNAL;
+    }
+    buffer_size += (size_t)written + 1;
+  }
+
+  buffer = (char *)malloc(buffer_size);
+  if (buffer == NULL) {
+    return CSPCL_ROUTE_ERR_NO_MEMORY;
+  }
+
+  for (size_t i = 0; i < count; i++) {
+    int written = snprintf(buffer + offset, buffer_size - offset, "%u",
+                           (unsigned)values[i]);
+    if (written < 0) {
+      free(buffer);
+      return CSPCL_ROUTE_ERR_INTERNAL;
+    }
+    offset += (size_t)written;
+    if (i + 1 < count) {
+      buffer[offset++] = ',';
+      buffer[offset] = '\0';
+    }
+  }
+
+  *out_text = buffer;
+  return CSPCL_ROUTE_OK;
+}
+
+static cspcl_route_error_t
+cspcl_provider_parse_line(cspcl_asabr_process_provider_t *provider,
+                          const char *line) {
+  if (strncmp(line, "STATUS=", 7) == 0) {
+    const char *value = line + 7;
+    if (strncmp(value, "FOUND", 5) == 0) {
+      provider->decision_status = CSPCL_ROUTE_DECISION_FOUND;
+    } else if (strncmp(value, "NO_ROUTE", 8) == 0) {
+      provider->decision_status = CSPCL_ROUTE_DECISION_NO_ROUTE;
+    } else if (strncmp(value, "PROVIDER_ERROR", 14) == 0) {
+      provider->decision_status = CSPCL_ROUTE_DECISION_PROVIDER_ERROR;
+    } else if (strncmp(value, "TIMEOUT", 7) == 0) {
+      provider->decision_status = CSPCL_ROUTE_DECISION_TIMEOUT;
+    } else {
+      return CSPCL_ROUTE_ERR_PROVIDER_FAILED;
+    }
+    return CSPCL_ROUTE_OK;
+  }
+
+  if (strncmp(line, "MODE=", 5) == 0) {
+    const char *value = line + 5;
+    if (strncmp(value, "NONE", 4) == 0) {
+      provider->mode = CSPCL_ROUTE_MODE_NONE;
+    } else if (strncmp(value, "UNICAST", 7) == 0) {
+      provider->mode = CSPCL_ROUTE_MODE_UNICAST;
+    } else if (strncmp(value, "MULTICAST", 9) == 0) {
+      provider->mode = CSPCL_ROUTE_MODE_MULTICAST;
+    } else {
+      return CSPCL_ROUTE_ERR_PROVIDER_FAILED;
+    }
+    return CSPCL_ROUTE_OK;
+  }
+
+  if (strncmp(line, "DIAG=", 5) == 0) {
+    strncpy(provider->diagnostic, line + 5, CSPCL_ROUTE_DIAGNOSTIC_MAX_LEN - 1);
+    provider->diagnostic[CSPCL_ROUTE_DIAGNOSTIC_MAX_LEN - 1] = '\0';
+    return CSPCL_ROUTE_OK;
+  }
+
+  if (strncmp(line, "HOP=", 4) == 0) {
+    unsigned int next_hop_node_id = 0;
+    unsigned long long contact_identifier = 0;
+    double estimated_arrival_time = 0.0;
+    int parsed = sscanf(line + 4, "%u,%llu,%lf", &next_hop_node_id,
+                        &contact_identifier, &estimated_arrival_time);
+    cspcl_route_error_t ensure_rc;
+
+    if (parsed != 3) {
+      return CSPCL_ROUTE_ERR_PROVIDER_FAILED;
+    }
+
+    ensure_rc =
+        cspcl_provider_ensure_capacity(provider, provider->next_hop_count + 1);
+    if (ensure_rc != CSPCL_ROUTE_OK) {
+      return ensure_rc;
+    }
+
+    provider->next_hops[provider->next_hop_count].next_hop_node_id =
+        (uint16_t)next_hop_node_id;
+    provider->next_hops[provider->next_hop_count].contact_identifier =
+        (uint64_t)contact_identifier;
+    provider->next_hops[provider->next_hop_count].estimated_arrival_time =
+        estimated_arrival_time;
+    provider->next_hop_count++;
+    return CSPCL_ROUTE_OK;
+  }
+
+  return CSPCL_ROUTE_OK;
+}
+
+static cspcl_route_error_t
+cspcl_provider_run_process(cspcl_asabr_process_provider_t *provider,
+                           const cspcl_route_request_t *request) {
+#ifndef FREERTOS
+  int pipe_fds[2];
+  pid_t child_pid;
+  char *destination_text = NULL;
+  char *excluded_text = NULL;
+  char timeout_text[32];
+  char source_text[32];
+  char priority_text[32];
+  char size_text[64];
+  char expiration_text[64];
+  char current_time_text[64];
+  char *argv[24];
+  size_t argv_index = 0;
+  FILE *stream = NULL;
+  char *line = NULL;
+  size_t line_capacity = 0;
+  ssize_t line_length;
+  int wait_status = 0;
+  cspcl_route_error_t rc = CSPCL_ROUTE_OK;
+
+  if (pipe(pipe_fds) != 0) {
+    return CSPCL_ROUTE_ERR_INTERNAL;
+  }
+
+  rc = cspcl_provider_join_u16_list(request->destination_node_ids,
+                                    request->destination_count,
+                                    &destination_text);
+  if (rc != CSPCL_ROUTE_OK) {
+    close(pipe_fds[0]);
+    close(pipe_fds[1]);
+    return rc;
+  }
+
+  rc = cspcl_provider_join_u16_list(
+      request->excluded_node_ids, request->excluded_node_count, &excluded_text);
+  if (rc != CSPCL_ROUTE_OK) {
+    free(destination_text);
+    close(pipe_fds[0]);
+    close(pipe_fds[1]);
+    return rc;
+  }
+
+  if (snprintf(source_text, sizeof(source_text), "%u",
+               (unsigned)request->source_node_id) < 0 ||
+      snprintf(priority_text, sizeof(priority_text), "%d",
+               (int)request->bundle_priority) < 0 ||
+      snprintf(size_text, sizeof(size_text), "%.17g", request->bundle_size) <
+          0 ||
+      snprintf(expiration_text, sizeof(expiration_text), "%.17g",
+               request->bundle_expiration) < 0 ||
+      snprintf(current_time_text, sizeof(current_time_text), "%.17g",
+               request->current_time) < 0 ||
+      snprintf(timeout_text, sizeof(timeout_text), "%u", request->timeout_ms) <
+          0) {
+    free(destination_text);
+    free(excluded_text);
+    close(pipe_fds[0]);
+    close(pipe_fds[1]);
+    return CSPCL_ROUTE_ERR_INTERNAL;
+  }
+
+  child_pid = fork();
+  if (child_pid < 0) {
+    free(destination_text);
+    free(excluded_text);
+    close(pipe_fds[0]);
+    close(pipe_fds[1]);
+    return CSPCL_ROUTE_ERR_INTERNAL;
+  }
+
+  if (child_pid == 0) {
+    dup2(pipe_fds[1], STDOUT_FILENO);
+    dup2(pipe_fds[1], STDERR_FILENO);
+    close(pipe_fds[0]);
+    close(pipe_fds[1]);
+
+    argv[argv_index++] = provider->adapter_binary_path;
+    argv[argv_index++] = "query";
+    argv[argv_index++] = "--cp";
+    argv[argv_index++] = provider->contact_plan_path;
+    argv[argv_index++] = "--source";
+    argv[argv_index++] = source_text;
+    argv[argv_index++] = "--dest";
+    argv[argv_index++] = destination_text;
+    argv[argv_index++] = "--priority";
+    argv[argv_index++] = priority_text;
+    argv[argv_index++] = "--size";
+    argv[argv_index++] = size_text;
+    argv[argv_index++] = "--expiration";
+    argv[argv_index++] = expiration_text;
+    argv[argv_index++] = "--current-time";
+    argv[argv_index++] = current_time_text;
+    argv[argv_index++] = "--timeout-ms";
+    argv[argv_index++] = timeout_text;
+    if (excluded_text[0] != '\0') {
+      argv[argv_index++] = "--excluded";
+      argv[argv_index++] = excluded_text;
+    }
+    argv[argv_index++] = NULL;
+
+    execvp(provider->adapter_binary_path, argv);
+    _exit(127);
+  }
+
+  close(pipe_fds[1]);
+  stream = fdopen(pipe_fds[0], "r");
+  if (stream == NULL) {
+    free(destination_text);
+    free(excluded_text);
+    close(pipe_fds[0]);
+    return CSPCL_ROUTE_ERR_INTERNAL;
+  }
+
+  cspcl_provider_reset_result(provider);
+
+  while ((line_length = getline(&line, &line_capacity, stream)) != -1) {
+    while (line_length > 0 &&
+           (line[line_length - 1] == '\n' || line[line_length - 1] == '\r')) {
+      line[--line_length] = '\0';
+    }
+
+    rc = cspcl_provider_parse_line(provider, line);
+    if (rc != CSPCL_ROUTE_OK) {
+      break;
+    }
+  }
+
+  free(line);
+  fclose(stream);
+  free(destination_text);
+  free(excluded_text);
+
+  if (waitpid(child_pid, &wait_status, 0) < 0) {
+    return CSPCL_ROUTE_ERR_INTERNAL;
+  }
+
+  if (rc != CSPCL_ROUTE_OK) {
+    return rc;
+  }
+
+  if (!WIFEXITED(wait_status) || WEXITSTATUS(wait_status) != 0) {
+    return CSPCL_ROUTE_ERR_PROVIDER_FAILED;
+  }
+
+  if (provider->diagnostic[0] == '\0') {
+    strncpy(provider->diagnostic, "asabr-process-ok",
+            CSPCL_ROUTE_DIAGNOSTIC_MAX_LEN - 1);
+    provider->diagnostic[CSPCL_ROUTE_DIAGNOSTIC_MAX_LEN - 1] = '\0';
+  }
+
+  return CSPCL_ROUTE_OK;
+#else
+  (void)provider;
+  (void)request;
+  return CSPCL_ROUTE_ERR_INTERNAL;
+#endif
+}
+
+static cspcl_route_error_t
+cspcl_asabr_process_provider_cb(const cspcl_route_request_t *request,
+                                cspcl_route_provider_output_t *output,
+                                void *user_ctx) {
+  cspcl_asabr_process_provider_ctx_t *ctx =
+      (cspcl_asabr_process_provider_ctx_t *)user_ctx;
+  cspcl_route_error_t rc;
+
+  if (ctx == NULL || ctx->provider == NULL || output == NULL ||
+      request == NULL) {
+    return CSPCL_ROUTE_ERR_INVALID_PARAM;
+  }
+
+  rc = cspcl_provider_run_process(ctx->provider, request);
+  if (rc != CSPCL_ROUTE_OK) {
+    return rc;
+  }
+
+  output->decision_status = ctx->provider->decision_status;
+  output->mode = ctx->provider->mode;
+  output->next_hops = ctx->provider->next_hops;
+  output->next_hop_count = ctx->provider->next_hop_count;
+  output->diagnostic = ctx->provider->diagnostic;
+
+  return CSPCL_ROUTE_OK;
+}
+
+cspcl_route_error_t
+cspcl_asabr_process_provider_init(cspcl_asabr_process_provider_t *provider,
+                                  const char *adapter_binary_path,
+                                  const char *contact_plan_path) {
+  const char *selected_binary_path;
+  const char *selected_contact_plan_path;
+
+  if (provider == NULL) {
+    return CSPCL_ROUTE_ERR_INVALID_PARAM;
+  }
+
+  memset(provider, 0, sizeof(*provider));
+
+  selected_binary_path =
+      cspcl_pick_config_value(adapter_binary_path, "CSPCL_ASABR_ADAPTER_BIN");
+  selected_contact_plan_path = cspcl_pick_config_value(
+      contact_plan_path, "CSPCL_ASABR_CONTACT_PLAN_PATH");
+
+  if (selected_binary_path == NULL || selected_contact_plan_path == NULL) {
+    return CSPCL_ROUTE_ERR_INVALID_PARAM;
+  }
+
+  provider->adapter_binary_path = cspcl_strdup_safe(selected_binary_path);
+  provider->contact_plan_path = cspcl_strdup_safe(selected_contact_plan_path);
+  if (provider->adapter_binary_path == NULL ||
+      provider->contact_plan_path == NULL) {
+    cspcl_asabr_process_provider_cleanup(provider);
+    return CSPCL_ROUTE_ERR_NO_MEMORY;
+  }
+
+  provider->diagnostic[0] = '\0';
+  provider->bridge_ctx = NULL;
+  return CSPCL_ROUTE_OK;
+}
+
+void cspcl_asabr_process_provider_cleanup(
+    cspcl_asabr_process_provider_t *provider) {
+  if (provider == NULL) {
+    return;
+  }
+
+  free(provider->adapter_binary_path);
+  free(provider->contact_plan_path);
+  free(provider->next_hops);
+  memset(provider, 0, sizeof(*provider));
+}
+
+cspcl_route_error_t cspcl_asabr_process_provider_register(
+    cspcl_route_bridge_t *bridge, cspcl_asabr_process_provider_t *provider) {
+  cspcl_asabr_process_provider_ctx_t *ctx;
+  cspcl_route_error_t rc;
+
+  if (bridge == NULL || provider == NULL) {
+    return CSPCL_ROUTE_ERR_INVALID_PARAM;
+  }
+
+  ctx = (cspcl_asabr_process_provider_ctx_t *)malloc(sizeof(*ctx));
+  if (ctx == NULL) {
+    return CSPCL_ROUTE_ERR_NO_MEMORY;
+  }
+
+  ctx->provider = provider;
+  provider->bridge_ctx = ctx;
+  rc = cspcl_route_bridge_register_provider(
+      bridge, cspcl_asabr_process_provider_cb, ctx);
+  if (rc != CSPCL_ROUTE_OK) {
+    provider->bridge_ctx = NULL;
+    free(ctx);
+    return rc;
+  }
+
+  return CSPCL_ROUTE_OK;
+}
+
+cspcl_route_error_t cspcl_asabr_process_provider_unregister(
+    cspcl_route_bridge_t *bridge, cspcl_asabr_process_provider_t *provider) {
+  cspcl_route_error_t rc;
+
+  if (bridge == NULL || provider == NULL) {
+    return CSPCL_ROUTE_ERR_INVALID_PARAM;
+  }
+
+  rc = cspcl_route_bridge_unregister_provider(bridge);
+  free(provider->bridge_ctx);
+  provider->bridge_ctx = NULL;
+  return rc;
+}

--- a/src/cspcl_asabr_process_provider.h
+++ b/src/cspcl_asabr_process_provider.h
@@ -1,0 +1,48 @@
+/**
+ * @file cspcl_asabr_process_provider.h
+ * @brief Process-based adapter for calling the A-SABR routing subprocess.
+ */
+
+#ifndef CSPCL_ASABR_PROCESS_PROVIDER_H
+#define CSPCL_ASABR_PROCESS_PROVIDER_H
+
+#include <stddef.h>
+
+#include "cspcl_route_bridge.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  char *adapter_binary_path;
+  char *contact_plan_path;
+  cspcl_route_next_hop_t *next_hops;
+  size_t next_hop_count;
+  size_t next_hop_capacity;
+  cspcl_route_mode_t mode;
+  cspcl_route_decision_status_t decision_status;
+  char diagnostic[CSPCL_ROUTE_DIAGNOSTIC_MAX_LEN];
+  void *bridge_ctx;
+} cspcl_asabr_process_provider_t;
+
+cspcl_route_error_t
+cspcl_asabr_process_provider_init(cspcl_asabr_process_provider_t *provider,
+                                  const char *adapter_binary_path,
+                                  const char *contact_plan_path);
+
+void cspcl_asabr_process_provider_cleanup(
+    cspcl_asabr_process_provider_t *provider);
+
+cspcl_route_error_t
+cspcl_asabr_process_provider_register(cspcl_route_bridge_t *bridge,
+                                      cspcl_asabr_process_provider_t *provider);
+
+cspcl_route_error_t cspcl_asabr_process_provider_unregister(
+    cspcl_route_bridge_t *bridge, cspcl_asabr_process_provider_t *provider);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CSPCL_ASABR_PROCESS_PROVIDER_H */

--- a/src/cspcl_route_bridge.c
+++ b/src/cspcl_route_bridge.c
@@ -1,0 +1,289 @@
+#include "cspcl_route_bridge.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static int cspcl_route_lock(cspcl_route_bridge_t *bridge) {
+#ifndef FREERTOS
+  return pthread_mutex_lock(&bridge->lock);
+#else
+  return xSemaphoreTake(bridge->lock, portMAX_DELAY) == pdTRUE ? 0 : -1;
+#endif
+}
+
+static int cspcl_route_unlock(cspcl_route_bridge_t *bridge) {
+#ifndef FREERTOS
+  return pthread_mutex_unlock(&bridge->lock);
+#else
+  return xSemaphoreGive(bridge->lock) == pdTRUE ? 0 : -1;
+#endif
+}
+
+static bool cspcl_route_mode_valid(cspcl_route_mode_t mode) {
+  return mode == CSPCL_ROUTE_MODE_NONE || mode == CSPCL_ROUTE_MODE_UNICAST ||
+         mode == CSPCL_ROUTE_MODE_MULTICAST;
+}
+
+static bool cspcl_route_decision_valid(cspcl_route_decision_status_t status) {
+  return status == CSPCL_ROUTE_DECISION_FOUND ||
+         status == CSPCL_ROUTE_DECISION_NO_ROUTE ||
+         status == CSPCL_ROUTE_DECISION_PROVIDER_ERROR ||
+         status == CSPCL_ROUTE_DECISION_TIMEOUT;
+}
+
+static cspcl_route_error_t
+cspcl_route_validate_request(const cspcl_route_request_t *request) {
+  if (request == NULL) {
+    return CSPCL_ROUTE_ERR_INVALID_PARAM;
+  }
+
+  if (request->destination_count == 0 ||
+      request->destination_node_ids == NULL) {
+    return CSPCL_ROUTE_ERR_INVALID_PARAM;
+  }
+
+  if (request->excluded_node_count > 0 && request->excluded_node_ids == NULL) {
+    return CSPCL_ROUTE_ERR_INVALID_PARAM;
+  }
+
+  return CSPCL_ROUTE_OK;
+}
+
+static cspcl_route_error_t cspcl_route_validate_provider_output(
+    const cspcl_route_provider_output_t *provider_output) {
+  if (provider_output == NULL) {
+    return CSPCL_ROUTE_ERR_PROVIDER_FAILED;
+  }
+
+  if (!cspcl_route_decision_valid(provider_output->decision_status)) {
+    return CSPCL_ROUTE_ERR_PROVIDER_FAILED;
+  }
+
+  if (!cspcl_route_mode_valid(provider_output->mode)) {
+    return CSPCL_ROUTE_ERR_PROVIDER_FAILED;
+  }
+
+  if (provider_output->decision_status == CSPCL_ROUTE_DECISION_FOUND) {
+    if (provider_output->next_hops == NULL ||
+        provider_output->next_hop_count == 0) {
+      return CSPCL_ROUTE_ERR_PROVIDER_FAILED;
+    }
+  } else {
+    if (provider_output->next_hop_count != 0) {
+      return CSPCL_ROUTE_ERR_PROVIDER_FAILED;
+    }
+  }
+
+  return CSPCL_ROUTE_OK;
+}
+
+cspcl_route_error_t cspcl_route_bridge_init(cspcl_route_bridge_t *bridge) {
+  if (bridge == NULL) {
+    return CSPCL_ROUTE_ERR_INVALID_PARAM;
+  }
+
+  if (bridge->initialized) {
+    return CSPCL_ROUTE_ERR_ALREADY_INITIALIZED;
+  }
+
+  memset(bridge, 0, sizeof(*bridge));
+
+#ifndef FREERTOS
+  if (pthread_mutex_init(&bridge->lock, NULL) != 0) {
+    return CSPCL_ROUTE_ERR_NO_MEMORY;
+  }
+#else
+  bridge->lock = xSemaphoreCreateMutex();
+  if (bridge->lock == NULL) {
+    return CSPCL_ROUTE_ERR_NO_MEMORY;
+  }
+#endif
+
+  bridge->initialized = true;
+  return CSPCL_ROUTE_OK;
+}
+
+void cspcl_route_bridge_cleanup(cspcl_route_bridge_t *bridge) {
+  if (bridge == NULL || !bridge->initialized) {
+    return;
+  }
+
+  if (cspcl_route_lock(bridge) != 0) {
+    return;
+  }
+
+  bridge->provider_cb = NULL;
+  bridge->provider_user_ctx = NULL;
+  bridge->initialized = false;
+
+  if (cspcl_route_unlock(bridge) != 0) {
+    return;
+  }
+
+#ifndef FREERTOS
+  pthread_mutex_destroy(&bridge->lock);
+#else
+  vSemaphoreDelete(bridge->lock);
+  bridge->lock = NULL;
+#endif
+}
+
+cspcl_route_error_t
+cspcl_route_bridge_register_provider(cspcl_route_bridge_t *bridge,
+                                     cspcl_route_provider_cb_t provider_cb,
+                                     void *provider_user_ctx) {
+  if (bridge == NULL || provider_cb == NULL) {
+    return CSPCL_ROUTE_ERR_INVALID_PARAM;
+  }
+
+  if (!bridge->initialized) {
+    return CSPCL_ROUTE_ERR_NOT_INITIALIZED;
+  }
+
+  if (cspcl_route_lock(bridge) != 0) {
+    return CSPCL_ROUTE_ERR_INTERNAL;
+  }
+
+  bridge->provider_cb = provider_cb;
+  bridge->provider_user_ctx = provider_user_ctx;
+
+  if (cspcl_route_unlock(bridge) != 0) {
+    return CSPCL_ROUTE_ERR_INTERNAL;
+  }
+
+  return CSPCL_ROUTE_OK;
+}
+
+cspcl_route_error_t
+cspcl_route_bridge_unregister_provider(cspcl_route_bridge_t *bridge) {
+  if (bridge == NULL) {
+    return CSPCL_ROUTE_ERR_INVALID_PARAM;
+  }
+
+  if (!bridge->initialized) {
+    return CSPCL_ROUTE_ERR_NOT_INITIALIZED;
+  }
+
+  if (cspcl_route_lock(bridge) != 0) {
+    return CSPCL_ROUTE_ERR_INTERNAL;
+  }
+
+  bridge->provider_cb = NULL;
+  bridge->provider_user_ctx = NULL;
+
+  if (cspcl_route_unlock(bridge) != 0) {
+    return CSPCL_ROUTE_ERR_INTERNAL;
+  }
+
+  return CSPCL_ROUTE_OK;
+}
+
+void cspcl_route_result_cleanup(cspcl_route_result_t *result) {
+  if (result == NULL) {
+    return;
+  }
+
+  if (result->next_hops != NULL) {
+    free(result->next_hops);
+  }
+
+  memset(result, 0, sizeof(*result));
+}
+
+cspcl_route_error_t
+cspcl_route_bridge_route(cspcl_route_bridge_t *bridge,
+                         const cspcl_route_request_t *request,
+                         cspcl_route_result_t *result) {
+  cspcl_route_provider_cb_t provider_cb = NULL;
+  void *provider_user_ctx = NULL;
+  cspcl_route_provider_output_t provider_output;
+  cspcl_route_error_t provider_rc;
+  cspcl_route_error_t validate_rc;
+
+  if (bridge == NULL || result == NULL) {
+    return CSPCL_ROUTE_ERR_INVALID_PARAM;
+  }
+
+  if (!bridge->initialized) {
+    return CSPCL_ROUTE_ERR_NOT_INITIALIZED;
+  }
+
+  validate_rc = cspcl_route_validate_request(request);
+  if (validate_rc != CSPCL_ROUTE_OK) {
+    return validate_rc;
+  }
+
+  memset(result, 0, sizeof(*result));
+
+  if (cspcl_route_lock(bridge) != 0) {
+    return CSPCL_ROUTE_ERR_INTERNAL;
+  }
+
+  provider_cb = bridge->provider_cb;
+  provider_user_ctx = bridge->provider_user_ctx;
+
+  if (cspcl_route_unlock(bridge) != 0) {
+    return CSPCL_ROUTE_ERR_INTERNAL;
+  }
+
+  if (provider_cb == NULL) {
+    return CSPCL_ROUTE_ERR_NO_PROVIDER;
+  }
+
+  memset(&provider_output, 0, sizeof(provider_output));
+  provider_rc = provider_cb(request, &provider_output, provider_user_ctx);
+  if (provider_rc != CSPCL_ROUTE_OK) {
+    return CSPCL_ROUTE_ERR_PROVIDER_FAILED;
+  }
+
+  validate_rc = cspcl_route_validate_provider_output(&provider_output);
+  if (validate_rc != CSPCL_ROUTE_OK) {
+    return validate_rc;
+  }
+
+  result->decision_status = provider_output.decision_status;
+  result->mode = provider_output.mode;
+  result->next_hop_count = provider_output.next_hop_count;
+
+  if (provider_output.next_hop_count > 0) {
+    size_t bytes =
+        provider_output.next_hop_count * sizeof(cspcl_route_next_hop_t);
+    result->next_hops = (cspcl_route_next_hop_t *)malloc(bytes);
+    if (result->next_hops == NULL) {
+      cspcl_route_result_cleanup(result);
+      return CSPCL_ROUTE_ERR_NO_MEMORY;
+    }
+    memcpy(result->next_hops, provider_output.next_hops, bytes);
+  }
+
+  if (provider_output.diagnostic != NULL) {
+    strncpy(result->diagnostic, provider_output.diagnostic,
+            CSPCL_ROUTE_DIAGNOSTIC_MAX_LEN - 1);
+    result->diagnostic[CSPCL_ROUTE_DIAGNOSTIC_MAX_LEN - 1] = '\0';
+  }
+
+  return CSPCL_ROUTE_OK;
+}
+
+const char *cspcl_route_strerror(cspcl_route_error_t err) {
+  switch (err) {
+  case CSPCL_ROUTE_OK:
+    return "Success";
+  case CSPCL_ROUTE_ERR_INVALID_PARAM:
+    return "Invalid parameter";
+  case CSPCL_ROUTE_ERR_NOT_INITIALIZED:
+    return "Route bridge not initialized";
+  case CSPCL_ROUTE_ERR_ALREADY_INITIALIZED:
+    return "Route bridge already initialized";
+  case CSPCL_ROUTE_ERR_NO_PROVIDER:
+    return "No route provider registered";
+  case CSPCL_ROUTE_ERR_PROVIDER_FAILED:
+    return "Route provider failed";
+  case CSPCL_ROUTE_ERR_NO_MEMORY:
+    return "Memory allocation failed";
+  case CSPCL_ROUTE_ERR_INTERNAL:
+    return "Internal route bridge error";
+  default:
+    return "Unknown route bridge error";
+  }
+}

--- a/src/cspcl_route_bridge.h
+++ b/src/cspcl_route_bridge.h
@@ -1,0 +1,168 @@
+/**
+ * @file cspcl_route_bridge.h
+ * @brief BPA-agnostic routing bridge API for CSPCL.
+ *
+ * This API defines a stable request/response contract that allows
+ * routing providers (e.g. A-SABR adapters) to be plugged into CSPCL
+ * without introducing BPA-specific types.
+ */
+
+#ifndef CSPCL_ROUTE_BRIDGE_H
+#define CSPCL_ROUTE_BRIDGE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#ifndef FREERTOS
+#include <pthread.h>
+#else
+#include <FreeRTOS.h>
+#include <semphr.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Maximum length copied into diagnostic output buffers. */
+#define CSPCL_ROUTE_DIAGNOSTIC_MAX_LEN 128
+
+/** Route mode produced by a provider. */
+typedef enum {
+  CSPCL_ROUTE_MODE_NONE = 0,
+  CSPCL_ROUTE_MODE_UNICAST,
+  CSPCL_ROUTE_MODE_MULTICAST
+} cspcl_route_mode_t;
+
+/** Decision status returned by a route provider. */
+typedef enum {
+  CSPCL_ROUTE_DECISION_FOUND = 0,
+  CSPCL_ROUTE_DECISION_NO_ROUTE,
+  CSPCL_ROUTE_DECISION_PROVIDER_ERROR,
+  CSPCL_ROUTE_DECISION_TIMEOUT
+} cspcl_route_decision_status_t;
+
+/**
+ * Bridge API return codes.
+ *
+ * These describe bridge-level operation success/failure (validation,
+ * lifecycle, provider registration/dispatch), not transport send status.
+ */
+typedef enum {
+  CSPCL_ROUTE_OK = 0,
+  CSPCL_ROUTE_ERR_INVALID_PARAM,
+  CSPCL_ROUTE_ERR_NOT_INITIALIZED,
+  CSPCL_ROUTE_ERR_ALREADY_INITIALIZED,
+  CSPCL_ROUTE_ERR_NO_PROVIDER,
+  CSPCL_ROUTE_ERR_PROVIDER_FAILED,
+  CSPCL_ROUTE_ERR_NO_MEMORY,
+  CSPCL_ROUTE_ERR_INTERNAL
+} cspcl_route_error_t;
+
+/** One next-hop selection returned by routing logic. */
+typedef struct {
+  uint16_t next_hop_node_id;
+  uint64_t contact_identifier;
+  double estimated_arrival_time;
+} cspcl_route_next_hop_t;
+
+/** Immutable route request input. Arrays are caller-owned borrows. */
+typedef struct {
+  uint16_t source_node_id;
+  const uint16_t *destination_node_ids;
+  size_t destination_count;
+  int8_t bundle_priority;
+  double bundle_size;
+  double bundle_expiration;
+  double current_time;
+  const uint16_t *excluded_node_ids;
+  size_t excluded_node_count;
+  uint32_t timeout_ms;
+} cspcl_route_request_t;
+
+/**
+ * Route result returned by bridge to caller.
+ *
+ * Memory ownership:
+ * - `next_hops` is heap-owned by this struct after route() returns.
+ * - Caller must release it via cspcl_route_result_cleanup().
+ */
+typedef struct {
+  cspcl_route_decision_status_t decision_status;
+  cspcl_route_mode_t mode;
+  cspcl_route_next_hop_t *next_hops;
+  size_t next_hop_count;
+  char diagnostic[CSPCL_ROUTE_DIAGNOSTIC_MAX_LEN];
+} cspcl_route_result_t;
+
+/**
+ * Lightweight provider output borrowed during callback execution.
+ *
+ * Memory ownership:
+ * - `next_hops` and `diagnostic` are provider-owned borrows that need only
+ *   remain valid for the duration of the callback.
+ * - Bridge deep-copies these into cspcl_route_result_t before returning.
+ */
+typedef struct {
+  cspcl_route_decision_status_t decision_status;
+  cspcl_route_mode_t mode;
+  const cspcl_route_next_hop_t *next_hops;
+  size_t next_hop_count;
+  const char *diagnostic;
+} cspcl_route_provider_output_t;
+
+/** Provider callback signature used by the route bridge. */
+typedef cspcl_route_error_t (*cspcl_route_provider_cb_t)(
+    const cspcl_route_request_t *request,
+    cspcl_route_provider_output_t *output,
+    void *user_ctx);
+
+/** Mutable bridge runtime and provider registration state. */
+typedef struct {
+  bool initialized;
+#ifndef FREERTOS
+  pthread_mutex_t lock;
+#else
+  SemaphoreHandle_t lock;
+#endif
+  cspcl_route_provider_cb_t provider_cb;
+  void *provider_user_ctx;
+} cspcl_route_bridge_t;
+
+/** Initialize a route bridge instance. */
+cspcl_route_error_t cspcl_route_bridge_init(cspcl_route_bridge_t *bridge);
+
+/** Cleanup a route bridge instance and clear provider registration. */
+void cspcl_route_bridge_cleanup(cspcl_route_bridge_t *bridge);
+
+/** Register or replace the route provider callback. */
+cspcl_route_error_t cspcl_route_bridge_register_provider(
+    cspcl_route_bridge_t *bridge,
+    cspcl_route_provider_cb_t provider_cb,
+    void *provider_user_ctx);
+
+/** Unregister the route provider callback. */
+cspcl_route_error_t
+cspcl_route_bridge_unregister_provider(cspcl_route_bridge_t *bridge);
+
+/**
+ * Execute routing using the registered provider.
+ *
+ * On success, `result` is fully owned by caller and must be released with
+ * cspcl_route_result_cleanup().
+ */
+cspcl_route_error_t cspcl_route_bridge_route(cspcl_route_bridge_t *bridge,
+                                             const cspcl_route_request_t *request,
+                                             cspcl_route_result_t *result);
+
+/** Release heap-owned fields in cspcl_route_result_t. */
+void cspcl_route_result_cleanup(cspcl_route_result_t *result);
+
+/** Error string helper for bridge return codes. */
+const char *cspcl_route_strerror(cspcl_route_error_t err);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CSPCL_ROUTE_BRIDGE_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(test_cspcl
 )
 
 target_include_directories(test_cspcl PRIVATE
-    ${CMAKE_SOURCE_DIR}/src
+    ${CSPCL_C_SOURCE_DIR}
     ${CSP_ALL_INCLUDE_DIRS}
 )
 
@@ -26,7 +26,7 @@ add_executable(test_cspcl_pool_integration
     test_cspcl_pool_integration.c
 )
 target_include_directories(test_cspcl_pool_integration PRIVATE
-    ${CMAKE_SOURCE_DIR}/src
+    ${CSPCL_C_SOURCE_DIR}
     ${CSP_ALL_INCLUDE_DIRS}
 )
 target_link_libraries(test_cspcl_pool_integration PRIVATE cspcl)

--- a/ud3tn-integration/src/cla_csp.c
+++ b/ud3tn-integration/src/cla_csp.c
@@ -98,6 +98,7 @@ struct csp_cla_config {
 
   /* CSPCL instance */
   cspcl_t cspcl;
+  uint8_t local_addr;
 
   /* Link management */
   struct htab_entrylist *param_htab_elem[CSP_PARAM_HTAB_SLOT_COUNT];
@@ -107,6 +108,11 @@ struct csp_cla_config {
   /* RX task control */
   bool rx_running;
   Semaphore_t rx_task_sem;
+
+  /* ASABR support */
+  bool asabr_enabled;
+  cspcl_route_bridge_t route_bridge;
+  cspcl_asabr_process_provider_t asabr_provider;
 };
 
 /**
@@ -245,7 +251,6 @@ static uint8_t parse_csp_port(const char *cla_addr) {
 
   return (uint8_t)port;
 }
-
 
 static char *create_cla_addr(uint8_t csp_addr, uint8_t csp_port) {
   char *addr = malloc(16);
@@ -488,6 +493,64 @@ static void csp_rx_task(void *p) {
 }
 
 /*===========================================================================*/
+/* TX Task                                                                    */
+/*===========================================================================*/
+
+static uint8_t resolve_tx_destination(struct csp_cla_config *cfg,
+                                      uint8_t fallback_addr, uint64_t tx_id,
+                                      size_t bundle_len) {
+  uint16_t destination = fallback_addr;
+  cspcl_route_request_t request;
+  const double now_s = (double)time(NULL);
+  cspcl_route_result_t result;
+
+  if (!cfg->asabr_enabled)
+    return fallback_addr;
+
+  memset(&request, 0, sizeof(request));
+  memset(&result, 0, sizeof(result));
+
+  request.source_node_id = cfg->local_addr;
+  request.destination_node_ids = &destination;
+  request.destination_count = 1;
+  request.bundle_priority = 0;
+  request.bundle_size = (double)bundle_len;
+  request.bundle_expiration = now_s + 3600.0;
+  request.current_time = now_s;
+  request.timeout_ms = 5000;
+
+  cspcl_route_error_t rc =
+      cspcl_route_bridge_route(&cfg->route_bridge, &request, &result);
+  if (rc != CSPCL_ROUTE_OK) {
+    log_info("asabr route failed tx_id=%" PRIu64 " fallback=%u err=%s", tx_id,
+             fallback_addr, cspcl_route_strerror(rc));
+    return fallback_addr;
+  }
+
+  if (result.decision_status == CSPCL_ROUTE_DECISION_FOUND &&
+      result.next_hop_count > 0) {
+    const uint16_t next_hop = result.next_hops[0].next_hop_node_id;
+    if (next_hop <= UINT8_MAX) {
+      const uint8_t selected = (uint8_t)next_hop;
+      log_info("asabr route tx_id=%" PRIu64
+               " diag=%s mode=%d next_hop=%u (fallback=%u)",
+               tx_id,
+               result.diagnostic[0] != '\0' ? result.diagnostic : "(none)",
+               (int)result.mode, selected, fallback_addr);
+      cspcl_route_result_cleanup(&result);
+      return selected;
+    }
+  }
+
+  log_info("asabr no-route tx_id=%" PRIu64 " status=%d diag=%s fallback=%u",
+           tx_id, (int)result.decision_status,
+           result.diagnostic[0] != '\0' ? result.diagnostic : "(none)",
+           fallback_addr);
+  cspcl_route_result_cleanup(&result);
+  return fallback_addr;
+}
+
+/*===========================================================================*/
 /* CLA VTable Implementation                                                  */
 /*===========================================================================*/
 
@@ -649,14 +712,17 @@ enum ud3tn_result csp_cla_end_packet(struct cla_link *link) {
     return UD3TN_OK;
   }
 
+  const uint8_t dest_addr =
+      resolve_tx_destination(config, csp_link->dest_addr, link->tx_id,
+                             (size_t)csp_link->tx_buffer_len);
+
   LOGF_DEBUG("CSP: Sending %zu bytes to csp:%u", csp_link->tx_buffer_len,
-             csp_link->dest_addr);
+             dest_addr);
 
   /* Send bundle via CSPCL */
-  cspcl_error_t err =
-      cspcl_send_bundle(&config->cspcl, csp_link->tx_buffer,
-                        csp_link->tx_buffer_len, csp_link->dest_addr,
-                        csp_link->dest_port);
+  cspcl_error_t err = cspcl_send_bundle(&config->cspcl, csp_link->tx_buffer,
+                                        csp_link->tx_buffer_len, dest_addr,
+                                        csp_link->dest_port);
 
   /* Reset TX buffer */
   csp_link->tx_buffer_len = 0;

--- a/unibo-integration/COMMANDS.md
+++ b/unibo-integration/COMMANDS.md
@@ -16,10 +16,35 @@ export LIBCSP_BUILD=$DTN_ROOT/libcsp/build
 EOF
 
 source ~/.bashrc
+export CSPCL_C_SRC=$CSPCL_DIR/rust-bindings/cspcl-sys/c_src
 
 # optional tracing (recommended while debugging convergence-layer failures)
 export CSPCLA_TRACE_PAYLOAD=1
 export CSPCLA_TRACE_BYTES=64
+
+# required to enable ASABR routing provider in unibo-bp-cspcl
+# adapter binary should be the cspcl-asabr-adapter executable
+export CSPCL_ASABR_ADAPTER_BIN=$CSPCL_DIR/rust-bindings/target/release/cspcl-asabr-adapter
+
+# use an epoch-time-compatible contact plan for live tests
+# (the example plan in A-SABR/examples is relative-time and may return NO_ROUTE)
+cat > /tmp/asabr-dtn-dynamic3.cp <<'EOF'
+node 0 n0
+node 1 n1
+node 2 n2
+contact 1 2 0 4000000000 evl 1000000 1
+EOF
+export CSPCL_ASABR_CONTACT_PLAN_PATH=/tmp/asabr-dtn-dynamic3.cp
+
+# build adapter binary if not already built
+cd "$CSPCL_DIR/rust-bindings"
+cargo build --release -p cspcl-asabr-adapter
+
+# optional: direct adapter sanity check before launching daemons
+$CSPCL_ASABR_ADAPTER_BIN query \
+  --cp "$CSPCL_ASABR_CONTACT_PLAN_PATH" \
+  --source 1 --dest 2 --priority 0 --size 64 \
+  --expiration $(($(date +%s)+3600)) --current-time $(date +%s) --timeout-ms 5000
 ```
 
 ## 1) Clean reset
@@ -43,9 +68,10 @@ cd "$INTEG_DIR"
 mkdir -p build
 
 gcc -O2 -Wall -Wextra \
-  src/cspcl_daemon.c ../src/cspcl.c \
+  src/cspcl_daemon.c $CSPCL_C_SRC/cspcl.c \
+  $CSPCL_C_SRC/cspcl_route_bridge.c $CSPCL_C_SRC/cspcl_asabr_process_provider.c \
   -o build/unibo-bp-cspcl \
-  -I../src \
+  -I$CSPCL_C_SRC \
   -I$DTN_ROOT/unibo-dtn/unibo-bp/include \
   -I$DTN_ROOT/libcsp/include \
   -I$DTN_ROOT/libcsp/build/include \
@@ -53,16 +79,19 @@ gcc -O2 -Wall -Wextra \
   -Wl,-rpath,$UNIBO_BP_LIB \
   -lunibo-bp-api \
   $LIBCSP_BUILD/libcsp.a \
-  -lzmq -lpthread -lm
+  -lzmq -lpthread -lm -lsocketcan
 ```
+
+If your libcsp build does not include SocketCAN objects, `-lsocketcan` is optional.
 
 Or if you want to build for CAN:
 
 ```bash
 gcc -O2 -Wall -Wextra \
-  src/cspcl_daemon.c ../src/cspcl.c \
+  src/cspcl_daemon.c $CSPCL_C_SRC/cspcl.c \
+  $CSPCL_C_SRC/cspcl_route_bridge.c $CSPCL_C_SRC/cspcl_asabr_process_provider.c \
   -o build/unibo-bp-cspcl \
-  -I../src \
+  -I$CSPCL_C_SRC \
   -I$DTN_ROOT/unibo-dtn/unibo-bp/include \
   -I$DTN_ROOT/libcsp/include \
   -I$DTN_ROOT/libcsp/build/include \
@@ -150,14 +179,20 @@ On both terminals, replace `zmqhub` with `can` if you built for CAN instead of Z
 
 ```bash
 cd "$INTEG_DIR"
-stdbuf -oL -eL ./build/unibo-bp-cspcl 1 10 zmqhub 2001 /tmp/unibo-node1 2>&1 | tee /tmp/cspcl-node1.log
+stdbuf -oL -eL env \
+  CSPCL_ASABR_ADAPTER_BIN="$CSPCL_ASABR_ADAPTER_BIN" \
+  CSPCL_ASABR_CONTACT_PLAN_PATH="$CSPCL_ASABR_CONTACT_PLAN_PATH" \
+  ./build/unibo-bp-cspcl 1 10 zmqhub 2001 /tmp/unibo-node1 2>&1 | tee /tmp/cspcl-node1.log
 ```
 
 ### Terminal 5: CSPCLA node2
 
 ```bash
 cd "$INTEG_DIR"
-stdbuf -oL -eL ./build/unibo-bp-cspcl 2 10 zmqhub 2002 /tmp/unibo-node2 2>&1 | tee /tmp/cspcl-node2.log
+stdbuf -oL -eL env \
+  CSPCL_ASABR_ADAPTER_BIN="$CSPCL_ASABR_ADAPTER_BIN" \
+  CSPCL_ASABR_CONTACT_PLAN_PATH="$CSPCL_ASABR_CONTACT_PLAN_PATH" \
+  ./build/unibo-bp-cspcl 2 10 zmqhub 2002 /tmp/unibo-node2 2>&1 | tee /tmp/cspcl-node2.log
 ```
 
 Sanity (any terminal):
@@ -165,6 +200,9 @@ Sanity (any terminal):
 ```bash
 pgrep -fa 'unibo-bp-cspcl'
 # expected: exactly 2 lines
+
+# ASABR must be enabled on both daemons
+grep -E 'asabr provider enabled' /tmp/cspcl-node1.log /tmp/cspcl-node2.log
 ```
 
 ### Terminal 6: sink
@@ -173,6 +211,9 @@ pgrep -fa 'unibo-bp-cspcl'
 cd /tmp/unibo-node2
 $UNIBO_BP_BIN/unibo-bp-sink ipn:2.55
 ```
+
+If sink throws a Unix socket "No such file or directory" error, ensure it is launched from
+the node working directory (`/tmp/unibo-node2`) after `unibo-bp start` is running.
 
 ## 6) Send
 
@@ -187,6 +228,14 @@ Expected:
 
 - sink prints `Received ... bytes from ipn:1.xxxxx`
 - payload is visible
+- sender log proves ASABR route selection, for example:
+  `asabr route tx_id=... diag=asabr-route-found mode=1 next_hop=2 ...`
+
+Quick proof command:
+
+```bash
+grep -E 'asabr route|tx success' /tmp/cspcl-node1.log
+```
 
 ## 7) If bundles buffer but do not send
 

--- a/unibo-integration/src/cspcl_daemon.c
+++ b/unibo-integration/src/cspcl_daemon.c
@@ -30,6 +30,8 @@
 /* ------------------------------------------------------------------------- */
 
 #include "cspcl.h"
+#include "cspcl_asabr_process_provider.h"
+#include "cspcl_route_bridge.h"
 #include <csp/csp.h>
 #include <csp/csp_rtable.h>
 #include <csp/interfaces/csp_if_zmqhub.h>
@@ -68,8 +70,7 @@
 
 #define DEFAULT_CSP_CLA_ID 2001
 
-struct csp_peer
-{
+struct csp_peer {
   bool used;
   uint8_t csp_addr;
   uint64_t link_id;
@@ -77,8 +78,7 @@ struct csp_peer
   bool link_open;
 };
 
-struct csp_cla_config
-{
+struct csp_cla_config {
   UniboBPCLAHandle handle;
   uint64_t cla_id;
 
@@ -91,6 +91,10 @@ struct csp_cla_config
 
   pthread_mutex_t lock;
   struct csp_peer peers[CSP_MAX_LINKS];
+
+  bool asabr_enabled;
+  cspcl_route_bridge_t route_bridge;
+  cspcl_asabr_process_provider_t asabr_provider;
 };
 
 static enum csp_iface_type g_iface_type = CSP_IFACE_ZMQHUB;
@@ -102,8 +106,7 @@ static struct csp_cla_config *g_active_cfg = NULL;
 #endif
 
 #ifdef CSPCLA_STANDALONE_MAIN
-struct cspcl_daemon_config
-{
+struct cspcl_daemon_config {
   uint8_t local_addr;
   uint8_t csp_port;
   uint64_t cla_id;
@@ -116,15 +119,13 @@ struct cspcl_daemon_config
 /* Helpers                                                                    */
 /* ------------------------------------------------------------------------- */
 
-static void log_bp_error(const char *what, UniboBPError err)
-{
+static void log_bp_error(const char *what, UniboBPError err) {
   fprintf(stderr, "[cspcla] %s failed: %s (%d)\n", what,
           unibo_bp_error_to_string(err), (int)err);
   fflush(stderr);
 }
 
-static void log_info(const char *fmt, ...)
-{
+static void log_info(const char *fmt, ...) {
   time_t now = time(NULL);
   struct tm tm_now;
   localtime_r(&now, &tm_now);
@@ -140,13 +141,11 @@ static void log_info(const char *fmt, ...)
   va_end(args);
 }
 
-static bool trace_payload_enabled(void)
-{
+static bool trace_payload_enabled(void) {
   static int initialized = 0;
   static bool enabled = false;
 
-  if (!initialized)
-  {
+  if (!initialized) {
     const char *env = getenv("CSPCLA_TRACE_PAYLOAD");
     enabled = (env != NULL && env[0] != '\0' && env[0] != '0');
     initialized = 1;
@@ -155,16 +154,13 @@ static bool trace_payload_enabled(void)
   return enabled;
 }
 
-static size_t trace_payload_max_bytes(void)
-{
+static size_t trace_payload_max_bytes(void) {
   static int initialized = 0;
   static size_t max_bytes = 64;
 
-  if (!initialized)
-  {
+  if (!initialized) {
     const char *env = getenv("CSPCLA_TRACE_BYTES");
-    if (env && env[0] != '\0')
-    {
+    if (env && env[0] != '\0') {
       char *end = NULL;
       unsigned long parsed = strtoul(env, &end, 10);
       if (end != env && *end == '\0' && parsed > 0)
@@ -177,8 +173,7 @@ static size_t trace_payload_max_bytes(void)
 }
 
 static void log_payload_preview(const char *tag, const uint8_t *buffer,
-                                size_t len)
-{
+                                size_t len) {
   if (!trace_payload_enabled() || !buffer || len == 0)
     return;
 
@@ -188,8 +183,7 @@ static void log_payload_preview(const char *tag, const uint8_t *buffer,
   char hexbuf[(3 * 64) + 1];
 
   size_t pos = 0;
-  for (size_t i = 0; i < rendered_len; ++i)
-  {
+  for (size_t i = 0; i < rendered_len; ++i) {
     pos +=
         (size_t)snprintf(&hexbuf[pos], sizeof(hexbuf) - pos, "%02x", buffer[i]);
     if (i + 1 < rendered_len)
@@ -201,14 +195,12 @@ static void log_payload_preview(const char *tag, const uint8_t *buffer,
            (rendered_len < len) ? " ..." : "");
 }
 
-static void log_bp_call_error(const char *what, UniboBPError err)
-{
+static void log_bp_call_error(const char *what, UniboBPError err) {
   if (err != UniboBP_NoError)
     log_bp_error(what, err);
 }
 
-static uint8_t parse_csp_addr(const char *cla_addr)
-{
+static uint8_t parse_csp_addr(const char *cla_addr) {
   if (!cla_addr)
     return 0;
 
@@ -223,8 +215,7 @@ static uint8_t parse_csp_addr(const char *cla_addr)
   return (uint8_t)addr;
 }
 
-static int parse_uint8_arg(const char *value, uint8_t *out)
-{
+static int parse_uint8_arg(const char *value, uint8_t *out) {
   char *end = NULL;
   errno = 0;
   unsigned long parsed = strtoul(value, &end, 10);
@@ -235,8 +226,7 @@ static int parse_uint8_arg(const char *value, uint8_t *out)
   return 0;
 }
 
-static int parse_uint64_arg(const char *value, uint64_t *out)
-{
+static int parse_uint64_arg(const char *value, uint64_t *out) {
   char *end = NULL;
   errno = 0;
   unsigned long long parsed = strtoull(value, &end, 10);
@@ -247,8 +237,7 @@ static int parse_uint64_arg(const char *value, uint64_t *out)
   return 0;
 }
 
-static int copy_iface_param(char *dst, size_t dst_len, const char *src)
-{
+static int copy_iface_param(char *dst, size_t dst_len, const char *src) {
   if (!dst || !src || dst_len == 0)
     return -1;
 
@@ -262,43 +251,37 @@ static int copy_iface_param(char *dst, size_t dst_len, const char *src)
 
 static int parse_iface_spec(const char *value, enum csp_iface_type *iface_type,
                             char *zmqhub_addr, size_t zmqhub_addr_len,
-                            char *can_iface, size_t can_iface_len)
-{
+                            char *can_iface, size_t can_iface_len) {
   if (!value || !iface_type || !zmqhub_addr || !can_iface)
     return -1;
 
-  if (strncmp(value, "zmqhub:", 7) == 0)
-  {
+  if (strncmp(value, "zmqhub:", 7) == 0) {
     if (copy_iface_param(zmqhub_addr, zmqhub_addr_len, value + 7) != 0)
       return -1;
     *iface_type = CSP_IFACE_ZMQHUB;
     return 0;
   }
 
-  if (strcmp(value, "zmqhub") == 0)
-  {
+  if (strcmp(value, "zmqhub") == 0) {
     *iface_type = CSP_IFACE_ZMQHUB;
     return 0;
   }
 
-  if (strncmp(value, "can:", 4) == 0)
-  {
+  if (strncmp(value, "can:", 4) == 0) {
     if (copy_iface_param(can_iface, can_iface_len, value + 4) != 0)
       return -1;
     *iface_type = CSP_IFACE_CAN;
     return 0;
   }
 
-  if (strcmp(value, "can") == 0)
-  {
+  if (strcmp(value, "can") == 0) {
     if (copy_iface_param(can_iface, can_iface_len, CSP_CAN_IFACE) != 0)
       return -1;
     *iface_type = CSP_IFACE_CAN;
     return 0;
   }
 
-  if (strcmp(value, "loopback") == 0)
-  {
+  if (strcmp(value, "loopback") == 0) {
     *iface_type = CSP_IFACE_LOOPBACK;
     return 0;
   }
@@ -307,8 +290,7 @@ static int parse_iface_spec(const char *value, enum csp_iface_type *iface_type,
 }
 
 #ifdef CSPCLA_STANDALONE_MAIN
-static void print_usage(const char *prog)
-{
+static void print_usage(const char *prog) {
   fprintf(stderr,
           "Usage (positional): %s <local_addr> <csp_port> [iface] [cla_id] "
           "[bp_directory]\n"
@@ -322,8 +304,7 @@ static void print_usage(const char *prog)
           prog, prog);
 }
 
-static void daemon_signal_handler(int sig)
-{
+static void daemon_signal_handler(int sig) {
   (void)sig;
   log_info("signal received, requesting shutdown");
   g_shutdown_requested = 1;
@@ -331,8 +312,7 @@ static void daemon_signal_handler(int sig)
     g_active_cfg->rx_running = false;
 }
 
-static int install_signal_handlers(void)
-{
+static int install_signal_handlers(void) {
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
   sa.sa_handler = daemon_signal_handler;
@@ -347,8 +327,7 @@ static int install_signal_handlers(void)
 }
 
 static int parse_daemon_args(int argc, char **argv,
-                             struct cspcl_daemon_config *cfg)
-{
+                             struct cspcl_daemon_config *cfg) {
   bool has_local_addr = false;
   bool has_csp_port = false;
 
@@ -363,8 +342,7 @@ static int parse_daemon_args(int argc, char **argv,
   if (copy_iface_param(g_can_iface, sizeof(g_can_iface), CSP_CAN_IFACE) != 0)
     return -1;
 
-  if (argc >= 3 && argv[1][0] != '-')
-  {
+  if (argc >= 3 && argv[1][0] != '-') {
     if (parse_uint8_arg(argv[1], &cfg->local_addr) != 0)
       return -1;
     has_local_addr = true;
@@ -385,10 +363,8 @@ static int parse_daemon_args(int argc, char **argv,
   }
 
   int opt;
-  while ((opt = getopt(argc, argv, "hl:p:i:c:d:")) != -1)
-  {
-    switch (opt)
-    {
+  while ((opt = getopt(argc, argv, "hl:p:i:c:d:")) != -1) {
+    switch (opt) {
     case 'l':
       if (parse_uint8_arg(optarg, &cfg->local_addr) != 0)
         return -1;
@@ -427,8 +403,7 @@ static int parse_daemon_args(int argc, char **argv,
 }
 #endif
 
-static uint8_t csp_addr_from_eid(ConstUniboBPEID eid)
-{
+static uint8_t csp_addr_from_eid(ConstUniboBPEID eid) {
   if (!eid)
     return 0;
 
@@ -444,10 +419,8 @@ static uint8_t csp_addr_from_eid(ConstUniboBPEID eid)
 }
 
 static struct csp_peer *find_peer_by_link_id(struct csp_cla_config *cfg,
-                                             uint64_t link_id)
-{
-  for (size_t i = 0; i < CSP_MAX_LINKS; ++i)
-  {
+                                             uint64_t link_id) {
+  for (size_t i = 0; i < CSP_MAX_LINKS; ++i) {
     if (cfg->peers[i].used && cfg->peers[i].link_id == link_id)
       return &cfg->peers[i];
   }
@@ -455,21 +428,17 @@ static struct csp_peer *find_peer_by_link_id(struct csp_cla_config *cfg,
 }
 
 static struct csp_peer *find_peer_by_addr(struct csp_cla_config *cfg,
-                                          uint8_t addr)
-{
-  for (size_t i = 0; i < CSP_MAX_LINKS; ++i)
-  {
+                                          uint8_t addr) {
+  for (size_t i = 0; i < CSP_MAX_LINKS; ++i) {
     if (cfg->peers[i].used && cfg->peers[i].csp_addr == addr)
       return &cfg->peers[i];
   }
   return NULL;
 }
 
-static int ensure_link_for_addr(struct csp_cla_config *cfg, uint8_t csp_addr)
-{
+static int ensure_link_for_addr(struct csp_cla_config *cfg, uint8_t csp_addr) {
   struct csp_peer *peer = find_peer_by_addr(cfg, csp_addr);
-  if (peer)
-  {
+  if (peer) {
     log_info("link already exists for csp_addr=%u link_id=%" PRIu64, csp_addr,
              peer->link_id);
     return 0;
@@ -478,25 +447,21 @@ static int ensure_link_for_addr(struct csp_cla_config *cfg, uint8_t csp_addr)
   log_info("creating new link for csp_addr=%u", csp_addr);
 
   size_t free_idx = CSP_MAX_LINKS;
-  for (size_t i = 0; i < CSP_MAX_LINKS; ++i)
-  {
-    if (!cfg->peers[i].used)
-    {
+  for (size_t i = 0; i < CSP_MAX_LINKS; ++i) {
+    if (!cfg->peers[i].used) {
       free_idx = i;
       break;
     }
   }
 
-  if (free_idx == CSP_MAX_LINKS)
-  {
+  if (free_idx == CSP_MAX_LINKS) {
     log_info("no free peer slots available (max=%u)", CSP_MAX_LINKS);
     return -1;
   }
 
   UniboBPIPN ipn = NULL;
   UniboBPError err = unibo_bp_eid_ipn_create(csp_addr, 0, &ipn);
-  if (err != UniboBP_NoError)
-  {
+  if (err != UniboBP_NoError) {
     log_bp_error("unibo_bp_eid_ipn_create", err);
     return -1;
   }
@@ -504,8 +469,7 @@ static int ensure_link_for_addr(struct csp_cla_config *cfg, uint8_t csp_addr)
   uint64_t link_id = 0;
   err = unibo_bp_cla_create_link(cfg->handle, unibo_bp_const_cast_eid(ipn),
                                  true, true, &link_id);
-  if (err != UniboBP_NoError)
-  {
+  if (err != UniboBP_NoError) {
     log_bp_error("unibo_bp_cla_create_link", err);
     unibo_bp_eid_destroy((UniboBPEID *)&ipn);
     return -1;
@@ -513,8 +477,7 @@ static int ensure_link_for_addr(struct csp_cla_config *cfg, uint8_t csp_addr)
 
   err = unibo_bp_cla_set_link_param(cfg->handle, link_id, false,
                                     CSPCL_MAX_BUNDLE_SIZE);
-  if (err != UniboBP_NoError)
-  {
+  if (err != UniboBP_NoError) {
     log_bp_error("unibo_bp_cla_set_link_param", err);
     unibo_bp_cla_destroy_link(cfg->handle, link_id);
     unibo_bp_eid_destroy((UniboBPEID *)&ipn);
@@ -523,14 +486,12 @@ static int ensure_link_for_addr(struct csp_cla_config *cfg, uint8_t csp_addr)
 
   err = unibo_bp_cla_start_observation_planned_neighbor(
       cfg->handle, unibo_bp_const_cast_eid(ipn));
-  if (err != UniboBP_NoError)
-  {
+  if (err != UniboBP_NoError) {
     log_bp_error("unibo_bp_cla_start_observation_planned_neighbor", err);
   }
 
   err = unibo_bp_cla_open_link(cfg->handle, link_id);
-  if (err != UniboBP_NoError)
-  {
+  if (err != UniboBP_NoError) {
     log_bp_error("unibo_bp_cla_open_link", err);
     unibo_bp_cla_destroy_link(cfg->handle, link_id);
     unibo_bp_eid_destroy((UniboBPEID *)&ipn);
@@ -549,11 +510,9 @@ static int ensure_link_for_addr(struct csp_cla_config *cfg, uint8_t csp_addr)
   return 0;
 }
 
-static void observe_default_peers(struct csp_cla_config *cfg)
-{
+static void observe_default_peers(struct csp_cla_config *cfg) {
   unsigned observed = 0;
-  for (uint8_t node = 1; node <= CSP_OBSERVE_MAX_NODE; ++node)
-  {
+  for (uint8_t node = 1; node <= CSP_OBSERVE_MAX_NODE; ++node) {
     if (node == cfg->local_addr)
       continue;
 
@@ -579,8 +538,7 @@ static void observe_default_peers(struct csp_cla_config *cfg)
  * Derived from Unibo-LTP bridge behavior: reliable-forward ECOS flag can be
  * used as one input to transmission policy decisions.
  */
-static bool pdu_prefers_reliable_ltp(ConstUniboBPCLAOutboundPDU pdu)
-{
+static bool pdu_prefers_reliable_ltp(ConstUniboBPCLAOutboundPDU pdu) {
   ConstUniboBPECOS ecos = unibo_bp_cla_outbound_pdu_get_ecos(pdu);
   if (!ecos)
     return false;
@@ -588,13 +546,66 @@ static bool pdu_prefers_reliable_ltp(ConstUniboBPCLAOutboundPDU pdu)
   return unibo_bp_ecos_get_flag(ecos, UniboBPECOSFlag_reliableForward);
 }
 
+static uint8_t resolve_tx_destination(struct csp_cla_config *cfg,
+                                      uint8_t fallback_addr, uint64_t tx_id,
+                                      size_t bundle_len) {
+  uint16_t destination = fallback_addr;
+  cspcl_route_request_t request;
+  const double now_s = (double)time(NULL);
+  cspcl_route_result_t result;
+
+  if (!cfg->asabr_enabled)
+    return fallback_addr;
+
+  memset(&request, 0, sizeof(request));
+  memset(&result, 0, sizeof(result));
+
+  request.source_node_id = cfg->local_addr;
+  request.destination_node_ids = &destination;
+  request.destination_count = 1;
+  request.bundle_priority = 0;
+  request.bundle_size = (double)bundle_len;
+  request.bundle_expiration = now_s + 3600.0;
+  request.current_time = now_s;
+  request.timeout_ms = 5000;
+
+  cspcl_route_error_t rc =
+      cspcl_route_bridge_route(&cfg->route_bridge, &request, &result);
+  if (rc != CSPCL_ROUTE_OK) {
+    log_info("asabr route failed tx_id=%" PRIu64 " fallback=%u err=%s", tx_id,
+             fallback_addr, cspcl_route_strerror(rc));
+    return fallback_addr;
+  }
+
+  if (result.decision_status == CSPCL_ROUTE_DECISION_FOUND &&
+      result.next_hop_count > 0) {
+    const uint16_t next_hop = result.next_hops[0].next_hop_node_id;
+    if (next_hop <= UINT8_MAX) {
+      const uint8_t selected = (uint8_t)next_hop;
+      log_info("asabr route tx_id=%" PRIu64
+               " diag=%s mode=%d next_hop=%u (fallback=%u)",
+               tx_id,
+               result.diagnostic[0] != '\0' ? result.diagnostic : "(none)",
+               (int)result.mode, selected, fallback_addr);
+      cspcl_route_result_cleanup(&result);
+      return selected;
+    }
+  }
+
+  log_info("asabr no-route tx_id=%" PRIu64 " status=%d diag=%s fallback=%u",
+           tx_id, (int)result.decision_status,
+           result.diagnostic[0] != '\0' ? result.diagnostic : "(none)",
+           fallback_addr);
+  cspcl_route_result_cleanup(&result);
+  return fallback_addr;
+}
+
 /* ------------------------------------------------------------------------- */
 /* BP callbacks                                                              */
 /* ------------------------------------------------------------------------- */
 
 static bool on_outbound_pdu(uint64_t link_id, ConstUniboBPCLAOutboundPDU pdu,
-                            void *user_arg)
-{
+                            void *user_arg) {
   struct csp_cla_config *cfg = user_arg;
   if (!cfg || !pdu)
     return false;
@@ -609,10 +620,10 @@ static bool on_outbound_pdu(uint64_t link_id, ConstUniboBPCLAOutboundPDU pdu,
 
   pthread_mutex_lock(&cfg->lock);
   struct csp_peer *peer = find_peer_by_link_id(cfg, link_id);
+  const uint8_t fallback_addr = peer ? peer->csp_addr : 0;
   pthread_mutex_unlock(&cfg->lock);
 
-  if (!peer)
-  {
+  if (!peer) {
     log_info("outbound_pdu: no peer for link_id=%" PRIu64 " tx_id=%" PRIu64,
              link_id, tx_id);
     (void)unibo_bp_cla_transmission_failure(cfg->handle, link_id, tx_id);
@@ -620,8 +631,7 @@ static bool on_outbound_pdu(uint64_t link_id, ConstUniboBPCLAOutboundPDU pdu,
   }
 
   uint8_t *buffer = malloc((size_t)len);
-  if (!buffer)
-  {
+  if (!buffer) {
     log_info("outbound_pdu: malloc failed len=%" PRIu64, len);
     (void)unibo_bp_cla_transmission_failure(cfg->handle, link_id, tx_id);
     return false;
@@ -629,12 +639,10 @@ static bool on_outbound_pdu(uint64_t link_id, ConstUniboBPCLAOutboundPDU pdu,
 
   uint64_t remaining = len;
   uint8_t *cursor = buffer;
-  while (remaining > 0)
-  {
+  while (remaining > 0) {
     const size_t chunk = (remaining > 4096U) ? 4096U : (size_t)remaining;
     const ssize_t n = read(fd, cursor, chunk);
-    if (n <= 0)
-    {
+    if (n <= 0) {
       log_info("outbound_pdu: read failed fd=%d errno=%d (%s)", fd, errno,
                strerror(errno));
       free(buffer);
@@ -649,16 +657,18 @@ static bool on_outbound_pdu(uint64_t link_id, ConstUniboBPCLAOutboundPDU pdu,
 
   (void)pdu_prefers_reliable_ltp(pdu);
 
+  const uint8_t dest_addr =
+      resolve_tx_destination(cfg, fallback_addr, tx_id, (size_t)len);
+
   log_payload_preview("tx", buffer, (size_t)len);
 
   cspcl_error_t cerr = cspcl_send_bundle(&cfg->cspcl, buffer, (size_t)len,
-                                         peer->csp_addr, cfg->csp_port);
+                                         dest_addr, cfg->csp_port);
   free(buffer);
 
-  if (cerr == CSPCL_OK)
-  {
+  if (cerr == CSPCL_OK) {
     log_info("tx success tx_id=%" PRIu64 " dst_csp=%u bytes=%" PRIu64, tx_id,
-             peer->csp_addr, len);
+             dest_addr, len);
     log_bp_call_error(
         "unibo_bp_cla_transmission_success",
         unibo_bp_cla_transmission_success(cfg->handle, link_id, tx_id));
@@ -666,15 +676,14 @@ static bool on_outbound_pdu(uint64_t link_id, ConstUniboBPCLAOutboundPDU pdu,
   }
 
   log_info("tx failure tx_id=%" PRIu64 " dst_csp=%u cspcl_err=%d", tx_id,
-           peer->csp_addr, (int)cerr);
+           dest_addr, (int)cerr);
   log_bp_call_error(
       "unibo_bp_cla_transmission_failure",
       unibo_bp_cla_transmission_failure(cfg->handle, link_id, tx_id));
   return false;
 }
 
-static void on_stop(void *user_arg)
-{
+static void on_stop(void *user_arg) {
   struct csp_cla_config *cfg = user_arg;
   log_info("stop callback received");
   if (cfg)
@@ -682,8 +691,7 @@ static void on_stop(void *user_arg)
 }
 
 static void on_update_config_flags(uint64_t enabled_flags,
-                                   uint64_t disabled_flags, void *user_arg)
-{
+                                   uint64_t disabled_flags, void *user_arg) {
   (void)user_arg;
   log_info("update_config_flags callback: enable=0x%" PRIx64
            " disable=0x%" PRIx64,
@@ -692,8 +700,7 @@ static void on_update_config_flags(uint64_t enabled_flags,
 
 static void on_add_contact(ConstUniboBPEID neighbor, bool uplink,
                            struct timeval *start_time, struct timeval *end_time,
-                           uint64_t xmit_rate_Bps, void *user_arg)
-{
+                           uint64_t xmit_rate_Bps, void *user_arg) {
   (void)start_time;
   (void)end_time;
   (void)xmit_rate_Bps;
@@ -703,8 +710,7 @@ static void on_add_contact(ConstUniboBPEID neighbor, bool uplink,
     return;
 
   const uint8_t csp_addr = csp_addr_from_eid(neighbor);
-  if (csp_addr == 0)
-  {
+  if (csp_addr == 0) {
     log_info("add_contact callback: could not map EID to CSP address");
     return;
   }
@@ -713,11 +719,9 @@ static void on_add_contact(ConstUniboBPEID neighbor, bool uplink,
            csp_addr);
 
   pthread_mutex_lock(&cfg->lock);
-  if (ensure_link_for_addr(cfg, csp_addr) == 0)
-  {
+  if (ensure_link_for_addr(cfg, csp_addr) == 0) {
     struct csp_peer *peer = find_peer_by_addr(cfg, csp_addr);
-    if (peer)
-    {
+    if (peer) {
       UniboBPError err = unibo_bp_cla_open_link(cfg->handle, peer->link_id);
       if (err != UniboBP_NoError)
         log_bp_error("unibo_bp_cla_open_link", err);
@@ -731,19 +735,16 @@ static void on_add_contact(ConstUniboBPEID neighbor, bool uplink,
 }
 
 static void on_remove_contact(ConstUniboBPEID neighbor, bool uplink,
-                              struct timeval *start_time, void *user_arg)
-{
+                              struct timeval *start_time, void *user_arg) {
   struct csp_cla_config *cfg = user_arg;
   const uint8_t csp_addr = csp_addr_from_eid(neighbor);
   log_info("remove_contact callback: uplink=%d csp_addr=%u", (int)uplink,
            csp_addr);
 
-  if (cfg)
-  {
+  if (cfg) {
     pthread_mutex_lock(&cfg->lock);
     struct csp_peer *peer = find_peer_by_addr(cfg, csp_addr);
-    if (peer)
-    {
+    if (peer) {
       UniboBPError err = unibo_bp_cla_close_link(cfg->handle, peer->link_id);
       if (err != UniboBP_NoError)
         log_bp_error("unibo_bp_cla_close_link", err);
@@ -760,8 +761,7 @@ static void on_remove_contact(ConstUniboBPEID neighbor, bool uplink,
 
 static void on_add_range(ConstUniboBPEID neighbor, bool uplink,
                          struct timeval *start_time, struct timeval *end_time,
-                         uint64_t owlt_s, void *user_arg)
-{
+                         uint64_t owlt_s, void *user_arg) {
   const uint8_t csp_addr = csp_addr_from_eid(neighbor);
   log_info("add_range callback: uplink=%d csp_addr=%u owlt=%" PRIu64,
            (int)uplink, csp_addr, owlt_s);
@@ -771,8 +771,7 @@ static void on_add_range(ConstUniboBPEID neighbor, bool uplink,
 }
 
 static void on_remove_range(ConstUniboBPEID neighbor, bool uplink,
-                            struct timeval *start_time, void *user_arg)
-{
+                            struct timeval *start_time, void *user_arg) {
   const uint8_t csp_addr = csp_addr_from_eid(neighbor);
   log_info("remove_range callback: uplink=%d csp_addr=%u", (int)uplink,
            csp_addr);
@@ -784,15 +783,13 @@ static void on_remove_range(ConstUniboBPEID neighbor, bool uplink,
 /* RX worker                                                                  */
 /* ------------------------------------------------------------------------- */
 
-static void *csp_rx_task(void *arg)
-{
+static void *csp_rx_task(void *arg) {
   struct csp_cla_config *cfg = arg;
   uint8_t bundle_buffer[CSP_RX_BUFFER_SIZE];
 
   log_info("rx thread started");
 
-  while (cfg->rx_running)
-  {
+  while (cfg->rx_running) {
     size_t bundle_len = sizeof(bundle_buffer);
     uint8_t src_addr = 0;
     uint8_t src_port = 0;
@@ -802,8 +799,7 @@ static void *csp_rx_task(void *arg)
 
     if (err == CSPCL_ERR_TIMEOUT)
       continue;
-    if (err != CSPCL_OK)
-    {
+    if (err != CSPCL_OK) {
       log_info("rx: cspcl_recv_bundle error=%d", (int)err);
       continue;
     }
@@ -812,8 +808,7 @@ static void *csp_rx_task(void *arg)
     log_payload_preview("rx", bundle_buffer, bundle_len);
 
     pthread_mutex_lock(&cfg->lock);
-    if (ensure_link_for_addr(cfg, src_addr) != 0)
-    {
+    if (ensure_link_for_addr(cfg, src_addr) != 0) {
       pthread_mutex_unlock(&cfg->lock);
       continue;
     }
@@ -822,27 +817,23 @@ static void *csp_rx_task(void *arg)
     uint64_t link_id = peer ? peer->link_id : 0;
     pthread_mutex_unlock(&cfg->lock);
 
-    if (link_id == 0)
-    {
+    if (link_id == 0) {
       log_info("rx: no link_id for src_csp=%u", src_addr);
       continue;
     }
 
     int fd = unibo_bp_cla_open_file(cfg->handle);
-    if (fd < 0)
-    {
+    if (fd < 0) {
       log_info("rx: unibo_bp_cla_open_file failed");
       continue;
     }
 
     size_t remaining = bundle_len;
     const uint8_t *cursor = bundle_buffer;
-    while (remaining > 0)
-    {
+    while (remaining > 0) {
       size_t chunk = (remaining > 4096U) ? 4096U : remaining;
       ssize_t n = write(fd, cursor, chunk);
-      if (n <= 0)
-      {
+      if (n <= 0) {
         log_info("rx: write failed fd=%d errno=%d (%s)", fd, errno,
                  strerror(errno));
         break;
@@ -852,8 +843,7 @@ static void *csp_rx_task(void *arg)
       cursor += n;
     }
 
-    if (remaining == 0)
-    {
+    if (remaining == 0) {
       lseek(fd, 0, SEEK_SET);
       UniboBPError in_err =
           unibo_bp_cla_inbound_pdu(cfg->handle, link_id, fd, bundle_len);
@@ -862,9 +852,7 @@ static void *csp_rx_task(void *arg)
       else
         log_info("rx: delivered inbound pdu link_id=%" PRIu64 " bytes=%zu",
                  link_id, bundle_len);
-    }
-    else
-    {
+    } else {
       log_info("rx: write to inbound fd incomplete, remaining=%zu", remaining);
     }
 
@@ -882,8 +870,7 @@ static void *csp_rx_task(void *arg)
 
 static int csp_cla_init(struct csp_cla_config *cfg, uint8_t local_addr,
                         uint8_t csp_port, uint64_t cla_id,
-                        const char *bp_directory)
-{
+                        const char *bp_directory) {
   memset(cfg, 0, sizeof(*cfg));
   cfg->local_addr = local_addr;
   cfg->csp_port = csp_port;
@@ -894,8 +881,7 @@ static int csp_cla_init(struct csp_cla_config *cfg, uint8_t local_addr,
            local_addr, csp_port, cla_id,
            bp_directory ? bp_directory : "(null)");
 
-  if (pthread_mutex_init(&cfg->lock, NULL) != 0)
-  {
+  if (pthread_mutex_init(&cfg->lock, NULL) != 0) {
     log_info("pthread_mutex_init failed");
     return -1;
   }
@@ -909,37 +895,82 @@ static int csp_cla_init(struct csp_cla_config *cfg, uint8_t local_addr,
   strncpy(cfg->cspcl.can_iface, g_can_iface, CSP_IFACE_PARAM_MAX - 1);
   cfg->cspcl.can_iface[CSP_IFACE_PARAM_MAX - 1] = '\0';
 
-  if (cspcl_init(&cfg->cspcl) != CSPCL_OK)
-  {
+  if (cspcl_init(&cfg->cspcl) != CSPCL_OK) {
     log_info("cspcl_init failed");
     return -1;
+  }
+
+  cspcl_route_error_t route_rc = cspcl_route_bridge_init(&cfg->route_bridge);
+  if (route_rc != CSPCL_ROUTE_OK) {
+    log_info("route bridge init failed: %s", cspcl_route_strerror(route_rc));
+    cspcl_cleanup(&cfg->cspcl);
+    return -1;
+  }
+
+  route_rc =
+      cspcl_asabr_process_provider_init(&cfg->asabr_provider, NULL, NULL);
+  if (route_rc != CSPCL_ROUTE_OK) {
+    log_info("asabr provider disabled: init failed (%s)",
+             cspcl_route_strerror(route_rc));
+  } else {
+    route_rc = cspcl_asabr_process_provider_register(&cfg->route_bridge,
+                                                     &cfg->asabr_provider);
+    if (route_rc != CSPCL_ROUTE_OK) {
+      log_info("asabr provider disabled: register failed (%s)",
+               cspcl_route_strerror(route_rc));
+      cspcl_asabr_process_provider_cleanup(&cfg->asabr_provider);
+    } else {
+      cfg->asabr_enabled = true;
+      log_info("asabr provider enabled");
+    }
   }
 
   if (!bp_directory)
     bp_directory = ".";
 
   UniboBPError err = unibo_bp_cla_connect(bp_directory, &cfg->handle);
-  if (err != UniboBP_NoError)
-  {
+  if (err != UniboBP_NoError) {
     log_bp_error("unibo_bp_cla_connect", err);
+    if (cfg->asabr_enabled) {
+      (void)cspcl_asabr_process_provider_unregister(&cfg->route_bridge,
+                                                    &cfg->asabr_provider);
+      cspcl_asabr_process_provider_cleanup(&cfg->asabr_provider);
+      cfg->asabr_enabled = false;
+    }
+    cspcl_route_bridge_cleanup(&cfg->route_bridge);
+    cspcl_cleanup(&cfg->cspcl);
     return -1;
   }
 
   log_info("connected to unibo-bp cla api");
 
   err = unibo_bp_cla_set_id(cfg->handle, cfg->cla_id);
-  if (err != UniboBP_NoError)
-  {
+  if (err != UniboBP_NoError) {
     log_bp_error("unibo_bp_cla_set_id", err);
     unibo_bp_cla_disconnect(&cfg->handle);
+    if (cfg->asabr_enabled) {
+      (void)cspcl_asabr_process_provider_unregister(&cfg->route_bridge,
+                                                    &cfg->asabr_provider);
+      cspcl_asabr_process_provider_cleanup(&cfg->asabr_provider);
+      cfg->asabr_enabled = false;
+    }
+    cspcl_route_bridge_cleanup(&cfg->route_bridge);
+    cspcl_cleanup(&cfg->cspcl);
     return -1;
   }
 
   err = unibo_bp_cla_set_cla_name(cfg->handle, "CSPCLA");
-  if (err != UniboBP_NoError)
-  {
+  if (err != UniboBP_NoError) {
     log_bp_error("unibo_bp_cla_set_cla_name", err);
     unibo_bp_cla_disconnect(&cfg->handle);
+    if (cfg->asabr_enabled) {
+      (void)cspcl_asabr_process_provider_unregister(&cfg->route_bridge,
+                                                    &cfg->asabr_provider);
+      cspcl_asabr_process_provider_cleanup(&cfg->asabr_provider);
+      cfg->asabr_enabled = false;
+    }
+    cspcl_route_bridge_cleanup(&cfg->route_bridge);
+    cspcl_cleanup(&cfg->cspcl);
     return -1;
   }
 
@@ -971,11 +1002,18 @@ static int csp_cla_init(struct csp_cla_config *cfg, uint8_t local_addr,
                                         : "(unset)");
 
   cfg->rx_running = true;
-  if (pthread_create(&cfg->rx_thread, NULL, csp_rx_task, cfg) != 0)
-  {
+  if (pthread_create(&cfg->rx_thread, NULL, csp_rx_task, cfg) != 0) {
     log_info("pthread_create rx thread failed");
     cfg->rx_running = false;
     unibo_bp_cla_disconnect(&cfg->handle);
+    if (cfg->asabr_enabled) {
+      (void)cspcl_asabr_process_provider_unregister(&cfg->route_bridge,
+                                                    &cfg->asabr_provider);
+      cspcl_asabr_process_provider_cleanup(&cfg->asabr_provider);
+      cfg->asabr_enabled = false;
+    }
+    cspcl_route_bridge_cleanup(&cfg->route_bridge);
+    cspcl_cleanup(&cfg->cspcl);
     return -1;
   }
 
@@ -984,8 +1022,7 @@ static int csp_cla_init(struct csp_cla_config *cfg, uint8_t local_addr,
   return 0;
 }
 
-static void csp_cla_cleanup(struct csp_cla_config *cfg)
-{
+static void csp_cla_cleanup(struct csp_cla_config *cfg) {
   if (!cfg)
     return;
 
@@ -995,8 +1032,7 @@ static void csp_cla_cleanup(struct csp_cla_config *cfg)
   if (cfg->rx_thread)
     pthread_join(cfg->rx_thread, NULL);
 
-  for (size_t i = 0; i < CSP_MAX_LINKS; ++i)
-  {
+  for (size_t i = 0; i < CSP_MAX_LINKS; ++i) {
     if (!cfg->peers[i].used)
       continue;
 
@@ -1013,6 +1049,14 @@ static void csp_cla_cleanup(struct csp_cla_config *cfg)
 
   if (cfg->handle)
     unibo_bp_cla_disconnect(&cfg->handle);
+
+  if (cfg->asabr_enabled) {
+    (void)cspcl_asabr_process_provider_unregister(&cfg->route_bridge,
+                                                  &cfg->asabr_provider);
+    cspcl_asabr_process_provider_cleanup(&cfg->asabr_provider);
+    cfg->asabr_enabled = false;
+  }
+  cspcl_route_bridge_cleanup(&cfg->route_bridge);
 
   cspcl_cleanup(&cfg->cspcl);
   pthread_mutex_destroy(&cfg->lock);
@@ -1035,8 +1079,7 @@ static void csp_cla_cleanup(struct csp_cla_config *cfg)
  * iface_type: zmqhub | can | loopback
  */
 int csp_cla_create_unibo_update(const char *const options[],
-                                size_t option_count)
-{
+                                size_t option_count) {
   if (option_count < 2 || option_count > 5)
     return -1;
 
@@ -1050,8 +1093,7 @@ int csp_cla_create_unibo_update(const char *const options[],
   if (copy_iface_param(g_can_iface, sizeof(g_can_iface), CSP_CAN_IFACE) != 0)
     return -1;
 
-  if (option_count >= 3)
-  {
+  if (option_count >= 3) {
     if (parse_iface_spec(options[2], &g_iface_type, g_zmqhub_addr,
                          sizeof(g_zmqhub_addr), g_can_iface,
                          sizeof(g_can_iface)) != 0)
@@ -1068,8 +1110,7 @@ int csp_cla_create_unibo_update(const char *const options[],
   if (!cfg)
     return -1;
 
-  if (csp_cla_init(cfg, local_addr, csp_port, cla_id, bp_directory) != 0)
-  {
+  if (csp_cla_init(cfg, local_addr, csp_port, cla_id, bp_directory) != 0) {
     free(cfg);
     return -1;
   }
@@ -1082,19 +1123,16 @@ int csp_cla_create_unibo_update(const char *const options[],
 }
 
 #ifdef CSPCLA_STANDALONE_MAIN
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
   struct cspcl_daemon_config daemon_cfg;
   const int parse_result = parse_daemon_args(argc, argv, &daemon_cfg);
-  if (parse_result != 0)
-  {
+  if (parse_result != 0) {
     if (parse_result < 0)
       print_usage(argv[0]);
     return (parse_result > 0) ? 0 : EXIT_FAILURE;
   }
 
-  if (install_signal_handlers() != 0)
-  {
+  if (install_signal_handlers() != 0) {
     perror("sigaction");
     return EXIT_FAILURE;
   }
@@ -1105,8 +1143,7 @@ int main(int argc, char **argv)
 
   struct csp_cla_config cfg;
   if (csp_cla_init(&cfg, daemon_cfg.local_addr, daemon_cfg.csp_port,
-                   daemon_cfg.cla_id, daemon_cfg.bp_directory) != 0)
-  {
+                   daemon_cfg.cla_id, daemon_cfg.bp_directory) != 0) {
     fprintf(stderr, "[cspcla] initialization failed\n");
     return EXIT_FAILURE;
   }

--- a/unibo-integration/src/cspcl_daemon.c
+++ b/unibo-integration/src/cspcl_daemon.c
@@ -34,7 +34,9 @@
 #include "cspcl_route_bridge.h"
 #include <csp/csp.h>
 #include <csp/csp_rtable.h>
+#ifdef CSP_HAVE_LIBZMQ
 #include <csp/interfaces/csp_if_zmqhub.h>
+#endif
 
 #ifdef CSP_USE_CAN
 #include <csp/drivers/can_socketcan.h>


### PR DESCRIPTION
## Description

We are not currently using any algorithm to determine the next hop for a bundle. This PR aims to fix this by integrating the A-SABR algorithm to our cspcl logic. 

## Related Issue

Closes #19 

## Type of Change

- [X] Breaking change
- [X] Documentation update

## Checklist

- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md).
- [ ] The stub-mode build passes: `cmake -DCSP_REPO_DIR=/path/to/libcsp .. && make && ctest --verbose`
- [ ] New/changed C code is formatted with `clang-format`.
- [ ] New/changed Rust code passes `cargo fmt` and `cargo clippy`.
- [ ] Tests have been added or updated for the change.
- [ ] `CHANGELOG.md` has been updated under `[Unreleased]`.
