### PR TITLE
Add a hardy adapter to the rust bindings

### DIFF
--- a/docs/api/rust.md
+++ b/docs/api/rust.md
@@ -14,7 +14,8 @@ The `cspcl` crate provides safe, idiomatic Rust bindings over the C library.
 
 ```toml
 [dependencies]
-cspcl = "0.1"
+cspcl = "0.4"
+futures = "0.3"
 ```
 
 For production use with real libcsp set the `CSP_PATH` environment variable before building:
@@ -35,57 +36,78 @@ pub struct Cspcl { /* ... */ }
 Owns the underlying `cspcl_t` instance. Resources are released automatically when
 the value is dropped.
 
-### `Cspcl::init`
+### `Cspcl::new`
 
 ```rust
-pub fn init(local_addr: u8) -> Result<Self, CspclerError>
+pub fn new(local: CspAddress, interface: Interface) -> Result<Self>
 ```
 
-Initialize CSPCL with the given local CSP node address.
-
-### `open_rx_socket`
-
-```rust
-pub fn open_rx_socket(&mut self) -> Result<(), CspclerError>
-```
-
-Bind the receive socket to the Bundle Protocol port. Call once before `recv_bundle`.
+Initialize CSPCL with the local CSP node address, CSP port, and interface.
 
 ### `send_bundle`
 
 ```rust
-pub fn send_bundle(&self, bundle: &[u8], dest_addr: u8) -> Result<(), CspclerError>
+pub fn send_bundle(&mut self, bundle: &[u8], dest: CspAddress) -> Result<()>
 ```
 
-Send a serialized BP7 bundle to `dest_addr`. Fragmentation via SFP is handled internally.
+Send a serialized BP7 bundle to `dest`. Fragmentation via SFP is handled internally.
 
-### `recv_bundle`
+### `inbound`
 
 ```rust
-pub fn recv_bundle(&self, timeout_ms: u32) -> Result<(Vec<u8>, u8), CspclerError>
+pub fn inbound(self) -> InboundStream
 ```
 
-Receive a complete bundle. Returns `(bundle_bytes, src_addr)`. Blocks until data
-arrives or `timeout_ms` elapses.
+Consume the handle and return a stream of inbound bundles.
+
+### `close_rx_socket`
+
+```rust
+pub fn close_rx_socket(self)
+```
+
+Cancel inbound receive work and close the receive socket.
 
 ---
 
-## Address Translation
+## Public Types
 
 ```rust
-// IPN / DTN endpoint to CSP address
-pub fn endpoint_to_addr(endpoint_id: &str) -> u8
+pub struct CspAddress {
+    pub addr: u8,
+    pub port: u8,
+}
 
-// CSP address to IPN endpoint string ("ipn:X.0")
-pub fn addr_to_endpoint(addr: u8) -> Result<String, CspclerError>
+pub struct Bundle {
+    pub data: Vec<u8>,
+    pub src_addr: u8,
+    pub src_port: u8,
+}
+
+pub enum Interface {
+    Zmq(String),
+    Can(String),
+    Loopback,
+}
 ```
+
+`CspAddress` also converts to and from two-byte `bytes::Bytes` values in
+`[addr, port]` order.
+
+### `InboundStream`
+
+```rust
+pub struct InboundStream { /* ... */ }
+```
+
+Implements `futures::Stream<Item = Result<Bundle>>`.
 
 ---
 
-## `CspclerError`
+## `Error`
 
 ```rust
-pub enum CspclerError {
+pub enum Error {
     InvalidParam,
     NoMemory,
     BundleTooLarge,
@@ -95,7 +117,15 @@ pub enum CspclerError {
     Sfp,
     NotInitialized,
     Connection,
-    Unknown(i32),
+    CspInit,
+    CspStackInit,
+    CspZmqhubInit,
+    CspCanInit,
+    CspCanNotSupported,
+    CspRouter,
+    PoolFull,
+    UnknownError(cspcl_sys::cspcl_error_t),
+    ParseAddress,
 }
 ```
 
@@ -106,24 +136,31 @@ Implements `std::error::Error` and `std::fmt::Display`.
 ## Example
 
 ```rust
-use cspcl::{Cspcl, CspclerError};
+use cspcl::{CspAddress, Cspcl, Error, Interface};
+use futures::StreamExt;
 
-fn transfer_bundle(bundle: &[u8], dest: u8) -> Result<(), CspclerError> {
-    let cspcl = Cspcl::init(1)?;
+fn transfer_bundle(bundle: &[u8], dest: CspAddress) -> Result<(), Error> {
+    let local = CspAddress { addr: 1, port: 10 };
+    let mut cspcl = Cspcl::new(local, Interface::Loopback)?;
     cspcl.send_bundle(bundle, dest)?;
     Ok(())
 }
 
-fn receive_loop() -> Result<(), CspclerError> {
-    let mut cspcl = Cspcl::init(1)?;
-    cspcl.open_rx_socket()?;
+async fn receive_loop() -> Result<(), Error> {
+    let local = CspAddress { addr: 1, port: 10 };
+    let cspcl = Cspcl::new(local, Interface::Loopback)?;
+    let mut inbound = cspcl.inbound();
 
-    loop {
-        match cspcl.recv_bundle(10_000) {
-            Ok((data, src)) => println!("Bundle from {}: {} bytes", src, data.len()),
-            Err(CspclerError::Timeout) => continue,
-            Err(e) => return Err(e),
-        }
+    while let Some(bundle) = inbound.next().await {
+        let bundle = bundle?;
+        println!(
+            "Bundle from {}:{}: {} bytes",
+            bundle.src_addr,
+            bundle.src_port,
+            bundle.data.len()
+        );
     }
+
+    Ok(())
 }
 ```

--- a/docs/api/rust.md
+++ b/docs/api/rust.md
@@ -47,7 +47,7 @@ Initialize CSPCL with the local CSP node address, CSP port, and interface.
 ### `send_bundle`
 
 ```rust
-pub fn send_bundle(&mut self, bundle: &[u8], dest: CspAddress) -> Result<()>
+pub fn send_bundle(&self, bundle: &[u8], dest: CspAddress) -> Result<()>
 ```
 
 Send a serialized BP7 bundle to `dest`. Fragmentation via SFP is handled internally.
@@ -55,15 +55,15 @@ Send a serialized BP7 bundle to `dest`. Fragmentation via SFP is handled interna
 ### `inbound`
 
 ```rust
-pub fn inbound(self) -> InboundStream
+pub fn inbound(self: Arc<Self>) -> InboundStream
 ```
 
-Consume the handle and return a stream of inbound bundles.
+Share the handle with a stream of inbound bundles.
 
 ### `close_rx_socket`
 
 ```rust
-pub fn close_rx_socket(self)
+pub fn close_rx_socket(&self)
 ```
 
 Cancel inbound receive work and close the receive socket.
@@ -138,18 +138,19 @@ Implements `std::error::Error` and `std::fmt::Display`.
 ```rust
 use cspcl::{CspAddress, Cspcl, Error, Interface};
 use futures::StreamExt;
+use std::sync::Arc;
 
 fn transfer_bundle(bundle: &[u8], dest: CspAddress) -> Result<(), Error> {
     let local = CspAddress { addr: 1, port: 10 };
-    let mut cspcl = Cspcl::new(local, Interface::Loopback)?;
+    let cspcl = Cspcl::new(local, Interface::Loopback)?;
     cspcl.send_bundle(bundle, dest)?;
     Ok(())
 }
 
 async fn receive_loop() -> Result<(), Error> {
     let local = CspAddress { addr: 1, port: 10 };
-    let cspcl = Cspcl::new(local, Interface::Loopback)?;
-    let mut inbound = cspcl.inbound();
+    let cspcl = Arc::new(Cspcl::new(local, Interface::Loopback)?);
+    let mut inbound = Arc::clone(&cspcl).inbound();
 
     while let Some(bundle) = inbound.next().await {
         let bundle = bundle?;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,23 +99,36 @@ Add the dependency:
 
 ```toml
 [dependencies]
-cspcl = "0.1"
+cspcl = "0.4"
+futures = "0.3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
 ```rust
-use cspcl::Cspcl;
+use cspcl::{CspAddress, Cspcl, Interface};
+use futures::StreamExt;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut node = Cspcl::init(1)?;
-    node.open_rx_socket()?;
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let local = CspAddress { addr: 1, port: 10 };
+    let mut node = Cspcl::new(local, Interface::Loopback)?;
 
     // Send
     let bundle: Vec<u8> = vec![/* BP7 bundle bytes */];
-    node.send_bundle(&bundle, 2)?;
+    let remote = CspAddress { addr: 2, port: 10 };
+    node.send_bundle(&bundle, remote)?;
 
-    // Receive (5 s timeout)
-    let (data, src_addr) = node.recv_bundle(5000)?;
-    println!("Received {} bytes from CSP addr {}", data.len(), src_addr);
+    // Receive from the inbound bundle stream.
+    let mut inbound = node.inbound();
+    while let Some(bundle) = inbound.next().await {
+        let bundle = bundle?;
+        println!(
+            "Received {} bytes from CSP {}:{}",
+            bundle.data.len(),
+            bundle.src_addr,
+            bundle.src_port
+        );
+    }
 
     Ok(())
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,11 +107,12 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```rust
 use cspcl::{CspAddress, Cspcl, Interface};
 use futures::StreamExt;
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let local = CspAddress { addr: 1, port: 10 };
-    let mut node = Cspcl::new(local, Interface::Loopback)?;
+    let node = Arc::new(Cspcl::new(local, Interface::Loopback)?);
 
     // Send
     let bundle: Vec<u8> = vec![/* BP7 bundle bytes */];
@@ -119,7 +120,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     node.send_bundle(&bundle, remote)?;
 
     // Receive from the inbound bundle stream.
-    let mut inbound = node.inbound();
+    let mut inbound = Arc::clone(&node).inbound();
     while let Some(bundle) = inbound.next().await {
         let bundle = bundle?;
         println!(

--- a/rust-bindings/Cargo.lock
+++ b/rust-bindings/Cargo.lock
@@ -3,6 +3,62 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr",
+ "ghash",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "aes-kw"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ac571010bd60765c56085a4f1d412012a9be2663b1a2f2b19b49318653fd0d"
+dependencies = [
+ "aes 0.9.1",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +66,44 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
@@ -28,26 +122,41 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex 2.0.1",
@@ -69,6 +178,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +206,76 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -100,16 +299,97 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.15.0"
+name = "ctr"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures"
@@ -167,7 +447,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -200,10 +480,221 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
+name = "hardy-async"
+version = "0.1.0"
+source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+dependencies = [
+ "async-trait",
+ "flume",
+ "futures",
+ "spin 0.12.0",
+ "time",
+ "tokio",
+ "tokio-util",
+ "trace-err",
+ "tracing",
+]
+
+[[package]]
+name = "hardy-bpa"
+version = "0.1.0"
+source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+dependencies = [
+ "arc-swap",
+ "base64",
+ "bytes",
+ "foldhash",
+ "futures",
+ "hardy-async",
+ "hardy-bpv7",
+ "hardy-cbor",
+ "hardy-eid-patterns",
+ "hashbrown",
+ "lru",
+ "metrics",
+ "rand",
+ "serde",
+ "thiserror",
+ "time",
+ "trace-err",
+ "tracing",
+]
+
+[[package]]
+name = "hardy-bpv7"
+version = "0.5.0"
+source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+dependencies = [
+ "aes-gcm",
+ "aes-kw",
+ "base64",
+ "crc",
+ "hardy-cbor",
+ "hashbrown",
+ "hmac",
+ "percent-encoding",
+ "portable-atomic",
+ "rand",
+ "serde",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "time",
+ "winnow",
+ "zeroize",
+]
+
+[[package]]
+name = "hardy-cbor"
+version = "1.0.0"
+source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+dependencies = [
+ "half",
+ "num-traits",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "hardy-cspcl"
+version = "0.1.0"
+dependencies = [
+ "cspcl",
+ "futures-util",
+ "hardy-async",
+ "hardy-bpa",
+ "hardy-bpv7",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hardy-eid-patterns"
+version = "0.3.0"
+source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+dependencies = [
+ "glob",
+ "hardy-bpv7",
+ "percent-encoding",
+ "serde",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "itertools"
@@ -215,10 +706,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.182"
+name = "js-sys"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -231,22 +732,64 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.29"
+name = "libm"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
 
 [[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "nom"
@@ -259,16 +802,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.16"
+name = "opaque-debug"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -277,7 +872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -291,18 +886,55 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.3"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -323,15 +955,68 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest",
+]
 
 [[package]]
 name = "shlex"
@@ -346,10 +1031,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1527984ca054dfca79333baec451042863f485fbee01b7bf6d911de915cac865"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -364,13 +1089,63 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "time"
+version = "0.3.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -379,8 +1154,12 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "libc",
+ "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
+ "windows-sys",
 ]
 
 [[package]]
@@ -391,7 +1170,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -403,6 +1182,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -416,6 +1196,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "trace-err"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f74d0870c543d68ea83cd81d58e03ef343bfc3a98ce7173b8085cd3b09a29a29"
+dependencies = [
+ "tracing",
 ]
 
 [[package]]
@@ -437,7 +1226,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -450,13 +1239,159 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]

--- a/rust-bindings/Cargo.lock
+++ b/rust-bindings/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
 name = "cspcl"
 version = "0.4.0"
 dependencies = [
+ "bytes",
  "cspcl-sys",
  "futures",
  "tokio",
@@ -546,7 +547,7 @@ dependencies = [
 [[package]]
 name = "hardy-async"
 version = "0.1.0"
-source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
 dependencies = [
  "async-trait",
  "flume",
@@ -562,7 +563,7 @@ dependencies = [
 [[package]]
 name = "hardy-bpa"
 version = "0.1.0"
-source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
 dependencies = [
  "arc-swap",
  "base64",
@@ -587,7 +588,7 @@ dependencies = [
 [[package]]
 name = "hardy-bpv7"
 version = "0.5.0"
-source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
 dependencies = [
  "aes-gcm",
  "aes-kw",
@@ -611,7 +612,7 @@ dependencies = [
 [[package]]
 name = "hardy-cbor"
 version = "1.0.0"
-source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
 dependencies = [
  "half",
  "num-traits",
@@ -623,6 +624,7 @@ dependencies = [
 name = "hardy-cspcl"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "cspcl",
  "futures-util",
  "hardy-async",
@@ -637,7 +639,7 @@ dependencies = [
 [[package]]
 name = "hardy-eid-patterns"
 version = "0.3.0"
-source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
 dependencies = [
  "glob",
  "hardy-bpv7",

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -3,8 +3,3 @@ resolver = "3"
 members = ["cspcl", "cspcl-sys", "hardy-cspcl"]
 [workspace.package]
 edition = "2024"
-
-[patch."https://github.com/ricktaylor/hardy.git"]
-hardy-async = { git = "https://github.com/hugoponthieu/hardy.git", branch = "cspcl-patches" }
-hardy-bpa = { git = "https://github.com/hugoponthieu/hardy.git", branch = "cspcl-patches" }
-hardy-bpv7 = { git = "https://github.com/hugoponthieu/hardy.git", branch = "cspcl-patches" }

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -1,3 +1,10 @@
 [workspace]
 resolver = "3"
-members = ["cspcl", "cspcl-sys"]
+members = ["cspcl", "cspcl-sys", "hardy-cspcl"]
+[workspace.package]
+edition = "2024"
+
+[patch."https://github.com/ricktaylor/hardy.git"]
+hardy-async = { git = "https://github.com/hugoponthieu/hardy.git", branch = "cspcl-patches" }
+hardy-bpa = { git = "https://github.com/hugoponthieu/hardy.git", branch = "cspcl-patches" }
+hardy-bpv7 = { git = "https://github.com/hugoponthieu/hardy.git", branch = "cspcl-patches" }

--- a/rust-bindings/cspcl-sys/Cargo.toml
+++ b/rust-bindings/cspcl-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cspcl-sys"
 version = "0.3.0"
-edition = "2024"
+edition.workspace = true
 description = "Raw FFI bindings for the cspcl library"
 authors = ["cspcl contributors"]
 license = "MIT"

--- a/rust-bindings/cspcl/Cargo.toml
+++ b/rust-bindings/cspcl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cspcl"
 version = "0.4.0"
-edition = "2024"
+edition.workspace = true
 description = "Rust bindings for the cspcl library"
 authors = ["cspcl contributors"]
 license = "MIT"

--- a/rust-bindings/cspcl/Cargo.toml
+++ b/rust-bindings/cspcl/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["cspcl"]
 
 [dependencies]
+bytes = "1.12.0"
 cspcl-sys = { version = "0.3", path = "../cspcl-sys" }
 futures = { version = "0.3", features = ["alloc"] }
 tokio = { version = "1.52.3", features = ["macros", "rt", "time"] }

--- a/rust-bindings/cspcl/README.md
+++ b/rust-bindings/cspcl/README.md
@@ -14,29 +14,40 @@ Safe Rust bindings for the CubeSat Space Protocol Convergence Layer (CSPCL), ena
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-cspcl = "0.1"
+cspcl = "0.4"
+futures = "0.3"
 ```
 
 Basic usage:
 ```rust
-use cspcl::Cspcl;
+use cspcl::{CspAddress, Cspcl, Interface};
+use futures::StreamExt;
 
-// Initialize with local CSP address
-let mut cspcl = Cspcl::init(1)?;
-cspcl.open_rx_socket()?;
+// Initialize with the local CSP address and port.
+let local = CspAddress { addr: 1, port: 10 };
+let mut cspcl = Cspcl::new(local, Interface::Loopback)?;
 
-// Send bundle to CSP address 2
+// Send a bundle to a remote CSP address and port.
 let bundle = vec![/* BP7 bundle data */];
-cspcl.send_bundle(&bundle, 2)?;
+let remote = CspAddress { addr: 2, port: 10 };
+cspcl.send_bundle(&bundle, remote)?;
 
-// Receive bundle (5 second timeout)
-let (data, src_addr) = cspcl.recv_bundle(5000)?;
-println!("Received {} bytes from CSP addr {}", data.len(), src_addr);
+// Consume the instance to create an inbound bundle stream.
+let mut inbound = cspcl.inbound();
+while let Some(bundle) = inbound.next().await {
+    let bundle = bundle?;
+    println!(
+        "Received {} bytes from CSP {}:{}",
+        bundle.data.len(),
+        bundle.src_addr,
+        bundle.src_port
+    );
+}
 ```
 
 ## Documentation
 
-See [main repository README](../../README.md) for complete documentation and examples.
+See the crate-level Rust documentation for the current public API.
 
 ## License
 

--- a/rust-bindings/cspcl/README.md
+++ b/rust-bindings/cspcl/README.md
@@ -22,18 +22,19 @@ Basic usage:
 ```rust
 use cspcl::{CspAddress, Cspcl, Interface};
 use futures::StreamExt;
+use std::sync::Arc;
 
 // Initialize with the local CSP address and port.
 let local = CspAddress { addr: 1, port: 10 };
-let mut cspcl = Cspcl::new(local, Interface::Loopback)?;
+let cspcl = Arc::new(Cspcl::new(local, Interface::Loopback)?);
 
 // Send a bundle to a remote CSP address and port.
 let bundle = vec![/* BP7 bundle data */];
 let remote = CspAddress { addr: 2, port: 10 };
 cspcl.send_bundle(&bundle, remote)?;
 
-// Consume the instance to create an inbound bundle stream.
-let mut inbound = cspcl.inbound();
+// Share the instance with an inbound bundle stream.
+let mut inbound = Arc::clone(&cspcl).inbound();
 while let Some(bundle) = inbound.next().await {
     let bundle = bundle?;
     println!(

--- a/rust-bindings/cspcl/src/address.rs
+++ b/rust-bindings/cspcl/src/address.rs
@@ -1,0 +1,27 @@
+use bytes::Bytes;
+
+use crate::Error::ParseAddress;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CspAddress {
+    pub addr: u8,
+    pub port: u8,
+}
+
+impl TryFrom<Bytes> for CspAddress {
+    type Error = crate::Error;
+
+    fn try_from(value: Bytes) -> Result<Self, Self::Error> {
+        let mut raw_addr = value.into_iter();
+        raw_addr.len().eq(&2).ok_or(ParseAddress)?;
+        let addr = raw_addr.next().ok_or(ParseAddress)?;
+        let port = raw_addr.next().ok_or(ParseAddress)?;
+        Ok(Self { addr, port })
+    }
+}
+
+impl From<CspAddress> for Bytes {
+    fn from(val: CspAddress) -> Self {
+        Bytes::from(vec![val.addr, val.port])
+    }
+}

--- a/rust-bindings/cspcl/src/bundle.rs
+++ b/rust-bindings/cspcl/src/bundle.rs
@@ -44,8 +44,8 @@ impl Cspcl {
         Ok(())
     }
 
-    pub async fn inbound(self) -> InboundStream {
+    pub fn inbound(self) -> InboundStream {
         let cspcl = Arc::new(self);
-        InboundStream::new(cspcl.clone()).await
+        InboundStream::new(cspcl.clone())
     }
 }

--- a/rust-bindings/cspcl/src/bundle.rs
+++ b/rust-bindings/cspcl/src/bundle.rs
@@ -18,7 +18,7 @@ impl Cspcl {
     ///
     /// # Returns
     /// Ok(()) on success, or Err(Error) if the operation failed
-    pub fn send_bundle(&mut self, bundle: &[u8], dest: CspAddress) -> Result<()> {
+    pub fn send_bundle(&self, bundle: &[u8], dest: CspAddress) -> Result<()> {
         if bundle.is_empty() {
             return Err(Error::InvalidParam);
         }
@@ -43,8 +43,7 @@ impl Cspcl {
         Ok(())
     }
 
-    pub fn inbound(self) -> InboundStream {
-        let cspcl = Arc::new(self);
-        InboundStream::new(cspcl.clone())
+    pub fn inbound(self: Arc<Self>) -> InboundStream {
+        InboundStream::new(self)
     }
 }

--- a/rust-bindings/cspcl/src/bundle.rs
+++ b/rust-bindings/cspcl/src/bundle.rs
@@ -14,8 +14,7 @@ impl Cspcl {
     ///
     /// # Arguments
     /// * `bundle` - The serialized bundle data to send
-    /// * `dest_addr` - Destination CSP address
-    /// * `dest_port` - Destination CSP port
+    /// * `dest` - Destination CSP address and port
     ///
     /// # Returns
     /// Ok(()) on success, or Err(Error) if the operation failed

--- a/rust-bindings/cspcl/src/bundle.rs
+++ b/rust-bindings/cspcl/src/bundle.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use tracing::{debug, error};
 
-use crate::InboundStream;
 use crate::error::{Error, Result};
 use crate::instance::Cspcl;
+use crate::{CspAddress, InboundStream};
 
 impl Cspcl {
     /// Send a bundle to a remote CSP address
@@ -19,22 +19,22 @@ impl Cspcl {
     ///
     /// # Returns
     /// Ok(()) on success, or Err(Error) if the operation failed
-    pub fn send_bundle(&mut self, bundle: &[u8], dest_addr: u8, dest_port: u8) -> Result<()> {
+    pub fn send_bundle(&mut self, bundle: &[u8], dest: CspAddress) -> Result<()> {
         if bundle.is_empty() {
             return Err(Error::InvalidParam);
         }
 
         let mut inner = self.inner_mut();
-        debug!("Sending bundle to {}:{}", dest_addr, dest_port);
-        match cspcl_sys::types::send_bundle(&mut inner, bundle, dest_addr, dest_port)
+        debug!("Sending bundle to {}:{}", dest.addr, dest.port);
+        match cspcl_sys::types::send_bundle(&mut inner, bundle, dest.addr, dest.port)
             .map_err(Error::from_raw)
         {
-            Ok(_) => debug!("Bundle sent to {}:{}", dest_addr, dest_port),
+            Ok(_) => debug!("Bundle sent to {}:{}", dest.addr, dest.port),
             Err(e) => {
                 error!(
                     "Could not send bundle to {}:{} : {}",
-                    dest_addr,
-                    dest_port,
+                    dest.addr,
+                    dest.port,
                     e.to_string()
                 );
                 return Err(e);

--- a/rust-bindings/cspcl/src/error.rs
+++ b/rust-bindings/cspcl/src/error.rs
@@ -38,6 +38,8 @@ pub enum Error {
     PoolFull,
     /// Error code returned by CSPCL that this crate does not know yet
     UnknownError(cspcl_sys::cspcl_error_t),
+    /// Error returned when the address parsing fails
+    ParseAddress,
 }
 
 impl Error {
@@ -92,6 +94,7 @@ impl Error {
             Self::CspCanNotSupported => "CAN support not compiled in",
             Self::CspRouter => "CSP router task start failed",
             Self::PoolFull => "Connection pool full",
+            Self::ParseAddress => "Could not parse csp address",
             Self::UnknownError(_) => "Unknown error",
         }
     }
@@ -115,6 +118,7 @@ impl Error {
             Self::CspCanNotSupported => cspcl_sys::cspcl_error_t_CSPCL_ERR_CSP_CAN_NOT_SUPPORTED,
             Self::CspRouter => cspcl_sys::cspcl_error_t_CSPCL_ERR_CSP_ROUTER,
             Self::PoolFull => cspcl_sys::cspcl_error_t_CSPCL_ERR_POOL_FULL,
+            Self::ParseAddress => 420,
             Self::UnknownError(code) => *code,
         }
     }

--- a/rust-bindings/cspcl/src/inbound.rs
+++ b/rust-bindings/cspcl/src/inbound.rs
@@ -44,7 +44,7 @@ impl Stream for InboundStream {
 }
 
 impl InboundStream {
-    pub async fn new(cspcl: Arc<Cspcl>) -> Self {
+    pub fn new(cspcl: Arc<Cspcl>) -> Self {
         let (tx, rx) = mpsc::unbounded();
         debug!("Creating inbound stream");
 

--- a/rust-bindings/cspcl/src/instance.rs
+++ b/rust-bindings/cspcl/src/instance.rs
@@ -9,7 +9,17 @@ use crate::{
 };
 
 /// Safe wrapper for CSPCL instance
-#[derive(Clone)]
+///
+/// `Cspcl` owns the underlying C resource and must not be cloned into another
+/// Rust owner that would also run cleanup on drop.
+///
+/// ```compile_fail
+/// use cspcl::Cspcl;
+///
+/// fn duplicate_cleanup_owner(cspcl: Cspcl) {
+///     let _clone = cspcl.clone();
+/// }
+/// ```
 pub struct Cspcl {
     inner: Arc<RwLock<cspcl_sys::cspcl_t>>,
     inbound_shutdown: CancellationToken,
@@ -33,7 +43,7 @@ impl Cspcl {
     }
 
     /// Close the receive socket
-    pub fn close_rx_socket(self) {
+    pub fn close_rx_socket(&self) {
         self.inbound_shutdown.cancel();
         let mut cspcl = self.inner_mut();
         cspcl_sys::types::close_rx_socket(&mut cspcl);

--- a/rust-bindings/cspcl/src/instance.rs
+++ b/rust-bindings/cspcl/src/instance.rs
@@ -3,7 +3,10 @@ use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use cspcl_sys::types::AcceptedConn;
 use tokio_util::sync::CancellationToken;
 
-use crate::error::{Error, Result, from_sys_result};
+use crate::{
+    CspAddress,
+    error::{Error, Result, from_sys_result},
+};
 
 /// Safe wrapper for CSPCL instance
 #[derive(Clone)]
@@ -14,10 +17,10 @@ pub struct Cspcl {
 
 impl Cspcl {
     /// Initialize a new CSPCL instance with local CSP address
-    pub fn new(local_addr: u8, local_port: u8, interface: super::Interface) -> Result<Self> {
+    pub fn new(local: CspAddress, interface: super::Interface) -> Result<Self> {
         let config = cspcl_sys::types::CspclConfig {
-            local_addr,
-            csp_port: local_port,
+            local_addr: local.addr,
+            csp_port: local.port,
             interface,
         };
 
@@ -44,11 +47,6 @@ impl Cspcl {
             accepted_conn,
         ))?;
         Ok(accepted_conn)
-    }
-
-    /// Get local CSP address
-    pub fn local_addr(&self) -> u8 {
-        self.inner().local_addr
     }
 
     /// Check if initialized

--- a/rust-bindings/cspcl/src/lib.rs
+++ b/rust-bindings/cspcl/src/lib.rs
@@ -4,12 +4,14 @@
 //! enabling transmission of BP7 bundles over CSP UDP.
 
 // Module declarations
+mod address;
 mod bundle;
 mod error;
 mod inbound;
 mod instance;
 
 // Public exports
+pub use address::CspAddress;
 pub use cspcl_sys::types::InterfaceConfig as Interface;
 pub use error::{Error, Result};
 pub use inbound::InboundStream;

--- a/rust-bindings/cspcl/src/lib.rs
+++ b/rust-bindings/cspcl/src/lib.rs
@@ -1,7 +1,7 @@
 //! Safe Rust bindings for CSPCL (CubeSat Space Protocol Convergence Layer)
 //!
 //! This crate provides high-level safe wrappers around the C CSPCL library,
-//! enabling transmission of BP7 bundles over CSP UDP.
+//! enabling transmission of BP7 bundles over CSP.
 
 // Module declarations
 mod address;
@@ -17,8 +17,12 @@ pub use error::{Error, Result};
 pub use inbound::InboundStream;
 pub use instance::Cspcl;
 
+/// Bundle received from an inbound CSP connection.
 pub struct Bundle {
+    /// Serialized bundle payload.
     pub data: Vec<u8>,
+    /// Source CSP node address.
     pub src_addr: u8,
+    /// Source CSP port.
     pub src_port: u8,
 }

--- a/rust-bindings/hardy-cspcl/Cargo.toml
+++ b/rust-bindings/hardy-cspcl/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "hardy-cspcl"
+version = "0.1.0"
+edition.workspace = true
+
+[lib]
+path = "src/lib.rs"
+crate-type = ["rlib"]
+
+[features]
+default = []
+serde = ["dep:serde", "hardy-bpv7/serde"]
+instrument = ["tracing/attributes"]
+
+[dependencies]
+hardy-bpa = { git = "https://github.com/ricktaylor/hardy.git" }
+hardy-async = { git = "https://github.com/ricktaylor/hardy.git" }
+hardy-bpv7 = { git = "https://github.com/ricktaylor/hardy.git" }
+tracing = { version = "0.1.44", default-features = false }
+thiserror = "2.0.18"
+tokio = { version = "1.51.1", features = ["time"] }
+serde = { version = "1.0.228", features = ["derive"], optional = true }
+cspcl-bindings = { path = "../cspcl", package = "cspcl" }
+futures-util = "0.3.32"

--- a/rust-bindings/hardy-cspcl/Cargo.toml
+++ b/rust-bindings/hardy-cspcl/Cargo.toml
@@ -22,3 +22,4 @@ tokio = { version = "1.51.1", features = ["time"] }
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 cspcl-bindings = { path = "../cspcl", package = "cspcl" }
 futures-util = "0.3.32"
+bytes = "1.12.0"

--- a/rust-bindings/hardy-cspcl/src/cla.rs
+++ b/rust-bindings/hardy-cspcl/src/cla.rs
@@ -15,6 +15,9 @@ impl cla::Cla for Cla {
 
     async fn on_register(&self, sink: Box<dyn cla::Sink>, _node_ids: &[NodeId]) {
         self.sink.call_once(|| sink.into());
+        self.register_peers()
+            .await
+            .expect("Sink must be registered at this point");
     }
 
     async fn on_unregister(&self) {

--- a/rust-bindings/hardy-cspcl/src/cla.rs
+++ b/rust-bindings/hardy-cspcl/src/cla.rs
@@ -3,7 +3,6 @@ use cspcl_bindings::CspAddress;
 use hardy_async::async_trait;
 use hardy_bpa::cla::{self, ClaAddress, ClaAddressType, ForwardBundleResult};
 use hardy_bpv7::eid::NodeId;
-use std::sync::Arc;
 use tracing::warn;
 
 use crate::Cla;
@@ -15,17 +14,11 @@ impl cla::Cla for Cla {
     }
 
     async fn on_register(&self, sink: Box<dyn cla::Sink>, _node_ids: &[NodeId]) {
-        let sink: Arc<dyn cla::Sink> = sink.into();
-        let sink = self.sink.call_once(|| sink);
-        let inbound_stream = self.transport.inbound_stream().await;
-        self.runtime
-            .write()
-            .start_inbound(sink.clone(), inbound_stream)
-            .await;
+        self.sink.call_once(|| sink.into());
     }
 
     async fn on_unregister(&self) {
-        self.unregister().await;
+        self.cleanup().await;
     }
 
     async fn forward(

--- a/rust-bindings/hardy-cspcl/src/cla.rs
+++ b/rust-bindings/hardy-cspcl/src/cla.rs
@@ -1,0 +1,55 @@
+use bytes::Bytes;
+use cspcl_bindings::CspAddress;
+use hardy_async::async_trait;
+use hardy_bpa::cla::{self, ClaAddress, ClaAddressType, ForwardBundleResult};
+use hardy_bpv7::eid::NodeId;
+use std::sync::Arc;
+use tracing::warn;
+
+use crate::Cla;
+
+#[async_trait]
+impl cla::Cla for Cla {
+    fn address_type(&self) -> Option<ClaAddressType> {
+        Some(ClaAddressType::Private)
+    }
+
+    async fn on_register(&self, sink: Box<dyn cla::Sink>, _node_ids: &[NodeId]) {
+        let sink: Arc<dyn cla::Sink> = sink.into();
+        let sink = self.sink.call_once(|| sink);
+        let inbound_stream = self.transport.inbound_stream().await;
+        self.runtime
+            .write()
+            .start_inbound(sink.clone(), inbound_stream)
+            .await;
+    }
+
+    async fn on_unregister(&self) {
+        self.unregister().await;
+    }
+
+    async fn forward(
+        &self,
+        _queue: Option<u32>,
+        cla_addr: &ClaAddress,
+        bundle: Bytes,
+    ) -> cla::Result<ForwardBundleResult> {
+        let ClaAddress::Private(raw_addr) = cla_addr else {
+            return Ok(ForwardBundleResult::NoNeighbour);
+        };
+
+        let csp_addr = CspAddress::try_from(raw_addr.clone())
+            .map_err(|e| cla::Error::Internal(Box::new(e)))?;
+
+        match self.transport.send_bundle(bundle, csp_addr).await {
+            Ok(_) => Ok(ForwardBundleResult::Sent),
+            Err(e) => {
+                warn!(
+                    "Failed to send CSP bundle to {}:{}: {e}",
+                    csp_addr.addr, csp_addr.port
+                );
+                Err(cla::Error::Internal(Box::new(e)))
+            }
+        }
+    }
+}

--- a/rust-bindings/hardy-cspcl/src/config.rs
+++ b/rust-bindings/hardy-cspcl/src/config.rs
@@ -1,0 +1,53 @@
+use hardy_bpv7::eid::NodeId;
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+pub enum Interface {
+    Loopback,
+    Can,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default, rename_all = "kebab-case"))]
+pub struct PeerConfig {
+    pub node_id: NodeId,
+    pub addr: u8,
+    pub port: u8,
+    pub heartbeat_interval: Option<u64>,
+}
+
+impl Default for PeerConfig {
+    fn default() -> Self {
+        Self {
+            node_id: "ipn:1.0".parse().expect("valid default node id"),
+            addr: 0,
+            port: 0,
+            heartbeat_interval: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default, rename_all = "kebab-case"))]
+pub struct Config {
+    pub local_addr: u8,
+    pub port: u8,
+    pub interface: Interface,
+    pub interface_name: String,
+    pub peers: Vec<PeerConfig>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            local_addr: 1,
+            port: 0,
+            interface: Interface::Loopback,
+            interface_name: "loopback".to_string(),
+            peers: Vec::new(),
+        }
+    }
+}

--- a/rust-bindings/hardy-cspcl/src/dispatcher.rs
+++ b/rust-bindings/hardy-cspcl/src/dispatcher.rs
@@ -1,43 +1,52 @@
 use cspcl_bindings::{CspAddress, InboundStream};
 use futures_util::TryStreamExt;
-use hardy_async::CancellationToken;
+use hardy_async::{CancellationToken, JoinHandle};
 use std::{collections::HashMap, sync::Arc};
 use tracing::{debug, info, warn};
 
 use hardy_bpa::{
     Bytes,
-    cla::{ClaAddress, Sink},
+    cla::{self, ClaAddress},
 };
 use hardy_bpv7::eid::NodeId;
-use tokio::task::{self, JoinHandle};
+use tokio::task::{self};
 
-pub struct Runtime {
-    pub csp_to_endpoint: HashMap<CspAddress, NodeId>,
-    polling_task: Option<JoinHandle<()>>,
+pub type DispatcherHandle = JoinHandle<()>;
+
+pub struct Dispatcher {
+    csp_to_endpoint: HashMap<CspAddress, NodeId>,
     cancel_polling_task: CancellationToken,
+    inbound: InboundStream,
+    sink: Arc<dyn cla::Sink>,
 }
 
-impl Runtime {
-    pub fn new(csp_to_endpoint: HashMap<CspAddress, NodeId>) -> Self {
+impl Dispatcher {
+    pub fn new(
+        csp_to_endpoint: HashMap<CspAddress, NodeId>,
+        cancel_polling_task: CancellationToken,
+        inbound: InboundStream,
+        sink: Arc<dyn cla::Sink>,
+    ) -> Self {
         Self {
             csp_to_endpoint,
-            polling_task: None,
-            cancel_polling_task: CancellationToken::new(),
+            cancel_polling_task,
+            inbound,
+            sink,
         }
     }
 
-    pub fn stop(&self) {
-        self.cancel_polling_task.cancel();
-    }
-
-    pub async fn start_inbound(&mut self, sink: Arc<dyn Sink>, mut inbound: InboundStream) {
+    pub async fn start_dispatch_inbound_bundle(mut self) -> DispatcherHandle {
         let csp_to_endpoint = self.csp_to_endpoint.clone();
-
         let csp_to_addr_iter = self.csp_to_endpoint.iter();
         for csp_node in csp_to_addr_iter {
             let raw_addr: Bytes = Into::into(*csp_node.0);
-            match sink
-                .add_peer(ClaAddress::Private(raw_addr), &[csp_node.1.clone()])
+            match self
+                .sink
+                .clone()
+                .add_peer(
+                    ClaAddress::Private(raw_addr),
+                    std::slice::from_ref(csp_node.1),
+                )
                 .await
             {
                 Ok(true) => debug!(
@@ -57,13 +66,14 @@ impl Runtime {
         let cancel_token = self.cancel_polling_task.child_token();
 
         info!("Starting polling task of inbound bundle stream");
+        let sink = self.sink.clone();
 
-        let polling_task = task::spawn(async move {
+        task::spawn(async move {
             loop {
                 debug!("Polling Hardy CSPCL inbound stream");
                 let next_bundle = tokio::select! {
                     _ = cancel_token.cancelled() => break,
-                    next_bundle = inbound.try_next() => next_bundle,
+                    next_bundle = self.inbound.try_next() => next_bundle,
                 };
                 let bundle = match next_bundle {
                     Ok(bundle) => match bundle {
@@ -108,7 +118,6 @@ impl Runtime {
                     ),
                 }
             }
-        });
-        self.polling_task = Some(polling_task);
+        })
     }
 }

--- a/rust-bindings/hardy-cspcl/src/dispatcher.rs
+++ b/rust-bindings/hardy-cspcl/src/dispatcher.rs
@@ -35,34 +35,8 @@ impl Dispatcher {
         }
     }
 
-    pub async fn start_dispatch_inbound_bundle(mut self) -> DispatcherHandle {
+    pub fn start_dispatch_inbound_bundle(mut self) -> DispatcherHandle {
         let csp_to_endpoint = self.csp_to_endpoint.clone();
-        let csp_to_addr_iter = self.csp_to_endpoint.iter();
-        for csp_node in csp_to_addr_iter {
-            let raw_addr: Bytes = Into::into(*csp_node.0);
-            match self
-                .sink
-                .clone()
-                .add_peer(
-                    ClaAddress::Private(raw_addr),
-                    std::slice::from_ref(csp_node.1),
-                )
-                .await
-            {
-                Ok(true) => debug!(
-                    "Registered CSP peer {}:{} as {}",
-                    csp_node.0.addr, csp_node.0.port, csp_node.1
-                ),
-                Ok(false) => debug!(
-                    "CSP peer {}:{} was already registered",
-                    csp_node.0.addr, csp_node.0.port
-                ),
-                Err(e) => warn!(
-                    "Failed to register CSP peer {}:{} as {}: {e}",
-                    csp_node.0.addr, csp_node.0.port, csp_node.1
-                ),
-            }
-        }
         let cancel_token = self.cancel_polling_task.child_token();
 
         info!("Starting polling task of inbound bundle stream");

--- a/rust-bindings/hardy-cspcl/src/lib.rs
+++ b/rust-bindings/hardy-cspcl/src/lib.rs
@@ -1,0 +1,129 @@
+mod config;
+mod runtime;
+mod transport;
+
+pub use config::{Config, Interface, PeerConfig};
+
+use hardy_async::async_trait;
+use hardy_async::sync::spin::{Once, RwLock};
+use hardy_bpa::Bytes;
+use hardy_bpa::bpa::BpaRegistration;
+use hardy_bpa::cla::{self, ClaAddress, ClaAddressType, CspAddress, ForwardBundleResult};
+use hardy_bpv7::eid::NodeId;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::{debug, warn};
+
+use crate::runtime::Runtime;
+use crate::transport::Transport;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("transport initialization failed: {0}")]
+    Init(#[from] transport::Error),
+    #[error("registration failed: {0}")]
+    Registration(#[from] cla::Error),
+    #[error("could not create cspcl: {0}")]
+    CscplInit(#[from] cspcl_bindings::Error),
+}
+
+pub struct Cla {
+    transport: transport::Transport,
+    runtime: RwLock<runtime::Runtime>,
+    sink: Once<Arc<dyn cla::Sink>>,
+}
+
+impl Cla {
+    pub fn new(config: &Config) -> Result<Self, Error> {
+        let interface: cspcl_bindings::Interface = match config.interface {
+            Interface::Loopback => cspcl_bindings::Interface::Loopback,
+            Interface::Can => cspcl_bindings::Interface::Can(config.interface_name.clone()),
+        };
+
+        let cspcl = Arc::new(RwLock::new(
+            cspcl_bindings::Cspcl::new(config.local_addr, config.port, interface)
+                .map_err(|e: cspcl_bindings::Error| Error::CscplInit(e))?,
+        ));
+
+        let peers = config.peers.clone();
+        let mut csp_to_endpoint = HashMap::<CspAddress, NodeId>::new();
+        for peer in peers {
+            let csp_address = CspAddress {
+                addr: peer.addr,
+                port: peer.port,
+            };
+            csp_to_endpoint.insert(csp_address, peer.node_id.clone());
+        }
+
+        let transport = Transport::new(cspcl.clone());
+        let runtime = RwLock::new(Runtime::new(csp_to_endpoint));
+
+        Ok(Self {
+            transport,
+            runtime,
+            sink: Once::new(),
+        })
+    }
+
+    pub async fn register(
+        self: &Arc<Self>,
+        bpa: &dyn BpaRegistration,
+        name: String,
+        policy: Option<Arc<dyn hardy_bpa::policy::EgressPolicy>>,
+    ) -> Result<(), Error> {
+        bpa.register_cla(name, self.clone(), policy).await?;
+        Ok(())
+    }
+
+    pub async fn unregister(&self) {
+        debug!("Unregistering cspcl...");
+        self.transport.cleanup();
+        self.runtime.write().stop();
+    }
+}
+
+#[async_trait]
+impl cla::Cla for Cla {
+    fn address_type(&self) -> Option<ClaAddressType> {
+        Some(ClaAddressType::Csp)
+    }
+
+    async fn on_register(&self, sink: Box<dyn cla::Sink>, _node_ids: &[NodeId]) {
+        let sink: Arc<dyn cla::Sink> = sink.into();
+        let sink = self.sink.call_once(|| sink);
+        let inbound_stream = self.transport.inbound_stream().await;
+        self.runtime
+            .write()
+            .start_inbound(sink.clone(), inbound_stream)
+            .await;
+    }
+
+    async fn on_unregister(&self) {
+        self.unregister().await;
+    }
+
+    async fn forward(
+        &self,
+        _queue: Option<u32>,
+        cla_addr: &ClaAddress,
+        bundle: Bytes,
+    ) -> cla::Result<ForwardBundleResult> {
+        let ClaAddress::Csp(csp_addr) = cla_addr else {
+            return Ok(ForwardBundleResult::NoNeighbour);
+        };
+        match self
+            .transport
+            .send_bundle(bundle, csp_addr.addr, csp_addr.port)
+            .await
+        {
+            Ok(_) => Ok(ForwardBundleResult::Sent),
+            Err(e) => {
+                warn!(
+                    "Failed to send CSP bundle to {}:{}: {e}",
+                    csp_addr.addr, csp_addr.port
+                );
+                Err(cla::Error::Internal(Box::new(e)))
+            }
+        }
+    }
+}

--- a/rust-bindings/hardy-cspcl/src/lib.rs
+++ b/rust-bindings/hardy-cspcl/src/lib.rs
@@ -1,19 +1,20 @@
 mod cla;
 mod config;
-mod runtime;
+mod dispatcher;
 mod transport;
 
 pub use config::{Config, Interface, PeerConfig};
 
 use cspcl_bindings::CspAddress;
+use hardy_async::CancellationToken;
 use hardy_async::sync::spin::{Once, RwLock};
-use hardy_bpa::bpa::BpaRegistration;
+use hardy_bpa::cla::Sink;
 use hardy_bpv7::eid::NodeId;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::debug;
 
-use crate::runtime::Runtime;
+use crate::dispatcher::Dispatcher;
 use crate::transport::Transport;
 
 #[derive(thiserror::Error, Debug)]
@@ -24,12 +25,16 @@ pub enum Error {
     Registration(#[from] hardy_bpa::cla::Error),
     #[error("could not create cspcl: {0}")]
     CscplInit(#[from] cspcl_bindings::Error),
+    #[error("Could not create dispatcher: {0}")]
+    Dispatcher(String),
 }
 
 pub struct Cla {
+    csp_to_endpoint: HashMap<CspAddress, NodeId>,
     transport: transport::Transport,
-    runtime: RwLock<runtime::Runtime>,
-    sink: Once<Arc<dyn hardy_bpa::cla::Sink>>,
+    cancel_dispatcher: CancellationToken,
+    sink: Once<Arc<dyn Sink>>,
+    dispatcher: Once<Dispatcher>,
 }
 
 impl Cla {
@@ -59,30 +64,43 @@ impl Cla {
             };
             csp_to_endpoint.insert(csp_address, peer.node_id.clone());
         }
-
         let transport = Transport::new(cspcl.clone());
-        let runtime = RwLock::new(Runtime::new(csp_to_endpoint));
 
         Ok(Self {
+            csp_to_endpoint,
             transport,
-            runtime,
+            cancel_dispatcher: CancellationToken::new(),
             sink: Once::new(),
+            dispatcher: Once::new(),
         })
     }
 
-    pub async fn register(
-        self: &Arc<Self>,
-        bpa: &dyn BpaRegistration,
-        name: String,
-        policy: Option<Arc<dyn hardy_bpa::policy::EgressPolicy>>,
-    ) -> Result<(), Error> {
-        bpa.register_cla(name, self.clone(), policy).await?;
-        Ok(())
+    pub fn build_dispatcher(&self) -> Result<&Dispatcher, Error> {
+        self.dispatcher.get().map_or_else(
+            || -> Result<&Dispatcher, Error> {
+                let inbound = self.transport.inbound_stream();
+                let sink = self
+                    .sink
+                    .get()
+                    .ok_or(Error::Dispatcher("Sink is not initialiazed".to_string()))?;
+
+                let dispatcher = self.dispatcher.call_once(|| {
+                    Dispatcher::new(
+                        self.csp_to_endpoint.clone(),
+                        self.cancel_dispatcher.clone(),
+                        inbound,
+                        sink.clone(),
+                    )
+                });
+                Ok(dispatcher)
+            },
+            Ok,
+        )
     }
 
-    pub async fn unregister(&self) {
+    pub async fn cleanup(&self) {
         debug!("Unregistering cspcl...");
         self.transport.cleanup();
-        self.runtime.write().stop();
+        self.cancel_dispatcher.cancel();
     }
 }

--- a/rust-bindings/hardy-cspcl/src/lib.rs
+++ b/rust-bindings/hardy-cspcl/src/lib.rs
@@ -3,16 +3,18 @@ mod config;
 mod dispatcher;
 mod transport;
 
+use bytes::Bytes;
 pub use config::{Config, Interface, PeerConfig};
 
 use cspcl_bindings::CspAddress;
 use hardy_async::CancellationToken;
 use hardy_async::sync::spin::{Once, RwLock};
-use hardy_bpa::cla::Sink;
+use hardy_bpa::cla::{ClaAddress, Sink};
 use hardy_bpv7::eid::NodeId;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::debug;
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
 
 use crate::dispatcher::Dispatcher;
 use crate::transport::Transport;
@@ -27,6 +29,8 @@ pub enum Error {
     CscplInit(#[from] cspcl_bindings::Error),
     #[error("Could not create dispatcher: {0}")]
     Dispatcher(String),
+    #[error("Sink is not registered")]
+    Sink,
 }
 
 pub struct Cla {
@@ -34,7 +38,6 @@ pub struct Cla {
     transport: transport::Transport,
     cancel_dispatcher: CancellationToken,
     sink: Once<Arc<dyn Sink>>,
-    dispatcher: Once<Dispatcher>,
 }
 
 impl Cla {
@@ -71,31 +74,51 @@ impl Cla {
             transport,
             cancel_dispatcher: CancellationToken::new(),
             sink: Once::new(),
-            dispatcher: Once::new(),
         })
     }
 
-    pub fn build_dispatcher(&self) -> Result<&Dispatcher, Error> {
-        self.dispatcher.get().map_or_else(
-            || -> Result<&Dispatcher, Error> {
-                let inbound = self.transport.inbound_stream();
-                let sink = self
-                    .sink
-                    .get()
-                    .ok_or(Error::Dispatcher("Sink is not initialiazed".to_string()))?;
+    fn sink(&self) -> Result<Arc<dyn Sink>, Error> {
+        self.sink.get().cloned().ok_or(Error::Sink)
+    }
 
-                let dispatcher = self.dispatcher.call_once(|| {
-                    Dispatcher::new(
-                        self.csp_to_endpoint.clone(),
-                        self.cancel_dispatcher.clone(),
-                        inbound,
-                        sink.clone(),
-                    )
-                });
-                Ok(dispatcher)
-            },
-            Ok,
+    pub fn start_dispatcher(&self) -> Result<JoinHandle<()>, Error> {
+        let inbound = self.transport.inbound_stream();
+        let sink = self.sink()?;
+        Ok(Dispatcher::new(
+            self.csp_to_endpoint.clone(),
+            self.cancel_dispatcher.clone(),
+            inbound,
+            sink.clone(),
         )
+        .start_dispatch_inbound_bundle())
+    }
+
+    async fn register_peers(&self) -> Result<(), Error> {
+        let sink = self.sink()?;
+
+        for csp_node in self.csp_to_endpoint.clone().iter() {
+            match sink
+                .add_peer(
+                    ClaAddress::Private(Into::<Bytes>::into(*csp_node.0)),
+                    std::slice::from_ref(csp_node.1),
+                )
+                .await
+            {
+                Ok(true) => debug!(
+                    "Registered CSP peer {}:{} as {}",
+                    csp_node.0.addr, csp_node.0.port, csp_node.1
+                ),
+                Ok(false) => debug!(
+                    "CSP peer {}:{} was already registered",
+                    csp_node.0.addr, csp_node.0.port
+                ),
+                Err(e) => warn!(
+                    "Failed to register CSP peer {}:{} as {}: {e}",
+                    csp_node.0.addr, csp_node.0.port, csp_node.1
+                ),
+            }
+        }
+        Ok(())
     }
 
     pub async fn cleanup(&self) {

--- a/rust-bindings/hardy-cspcl/src/lib.rs
+++ b/rust-bindings/hardy-cspcl/src/lib.rs
@@ -8,7 +8,7 @@ pub use config::{Config, Interface, PeerConfig};
 
 use cspcl_bindings::CspAddress;
 use hardy_async::CancellationToken;
-use hardy_async::sync::spin::{Once, RwLock};
+use hardy_async::sync::spin::Once;
 use hardy_bpa::cla::{ClaAddress, Sink};
 use hardy_bpv7::eid::NodeId;
 use std::collections::HashMap;
@@ -47,7 +47,7 @@ impl Cla {
             Interface::Can => cspcl_bindings::Interface::Can(config.interface_name.clone()),
         };
 
-        let cspcl = Arc::new(RwLock::new(
+        let cspcl = Arc::new(
             cspcl_bindings::Cspcl::new(
                 CspAddress {
                     addr: config.local_addr,
@@ -56,7 +56,7 @@ impl Cla {
                 interface,
             )
             .map_err(|e: cspcl_bindings::Error| Error::CscplInit(e))?,
-        ));
+        );
 
         let peers = config.peers.clone();
         let mut csp_to_endpoint = HashMap::<CspAddress, NodeId>::new();

--- a/rust-bindings/hardy-cspcl/src/lib.rs
+++ b/rust-bindings/hardy-cspcl/src/lib.rs
@@ -1,18 +1,17 @@
+mod cla;
 mod config;
 mod runtime;
 mod transport;
 
 pub use config::{Config, Interface, PeerConfig};
 
-use hardy_async::async_trait;
+use cspcl_bindings::CspAddress;
 use hardy_async::sync::spin::{Once, RwLock};
-use hardy_bpa::Bytes;
 use hardy_bpa::bpa::BpaRegistration;
-use hardy_bpa::cla::{self, ClaAddress, ClaAddressType, CspAddress, ForwardBundleResult};
 use hardy_bpv7::eid::NodeId;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::runtime::Runtime;
 use crate::transport::Transport;
@@ -22,7 +21,7 @@ pub enum Error {
     #[error("transport initialization failed: {0}")]
     Init(#[from] transport::Error),
     #[error("registration failed: {0}")]
-    Registration(#[from] cla::Error),
+    Registration(#[from] hardy_bpa::cla::Error),
     #[error("could not create cspcl: {0}")]
     CscplInit(#[from] cspcl_bindings::Error),
 }
@@ -30,7 +29,7 @@ pub enum Error {
 pub struct Cla {
     transport: transport::Transport,
     runtime: RwLock<runtime::Runtime>,
-    sink: Once<Arc<dyn cla::Sink>>,
+    sink: Once<Arc<dyn hardy_bpa::cla::Sink>>,
 }
 
 impl Cla {
@@ -41,8 +40,14 @@ impl Cla {
         };
 
         let cspcl = Arc::new(RwLock::new(
-            cspcl_bindings::Cspcl::new(config.local_addr, config.port, interface)
-                .map_err(|e: cspcl_bindings::Error| Error::CscplInit(e))?,
+            cspcl_bindings::Cspcl::new(
+                CspAddress {
+                    addr: config.local_addr,
+                    port: config.port,
+                },
+                interface,
+            )
+            .map_err(|e: cspcl_bindings::Error| Error::CscplInit(e))?,
         ));
 
         let peers = config.peers.clone();
@@ -79,51 +84,5 @@ impl Cla {
         debug!("Unregistering cspcl...");
         self.transport.cleanup();
         self.runtime.write().stop();
-    }
-}
-
-#[async_trait]
-impl cla::Cla for Cla {
-    fn address_type(&self) -> Option<ClaAddressType> {
-        Some(ClaAddressType::Csp)
-    }
-
-    async fn on_register(&self, sink: Box<dyn cla::Sink>, _node_ids: &[NodeId]) {
-        let sink: Arc<dyn cla::Sink> = sink.into();
-        let sink = self.sink.call_once(|| sink);
-        let inbound_stream = self.transport.inbound_stream().await;
-        self.runtime
-            .write()
-            .start_inbound(sink.clone(), inbound_stream)
-            .await;
-    }
-
-    async fn on_unregister(&self) {
-        self.unregister().await;
-    }
-
-    async fn forward(
-        &self,
-        _queue: Option<u32>,
-        cla_addr: &ClaAddress,
-        bundle: Bytes,
-    ) -> cla::Result<ForwardBundleResult> {
-        let ClaAddress::Csp(csp_addr) = cla_addr else {
-            return Ok(ForwardBundleResult::NoNeighbour);
-        };
-        match self
-            .transport
-            .send_bundle(bundle, csp_addr.addr, csp_addr.port)
-            .await
-        {
-            Ok(_) => Ok(ForwardBundleResult::Sent),
-            Err(e) => {
-                warn!(
-                    "Failed to send CSP bundle to {}:{}: {e}",
-                    csp_addr.addr, csp_addr.port
-                );
-                Err(cla::Error::Internal(Box::new(e)))
-            }
-        }
     }
 }

--- a/rust-bindings/hardy-cspcl/src/runtime.rs
+++ b/rust-bindings/hardy-cspcl/src/runtime.rs
@@ -1,0 +1,109 @@
+use cspcl_bindings::InboundStream;
+use futures_util::TryStreamExt;
+use hardy_async::CancellationToken;
+use std::{collections::HashMap, sync::Arc};
+use tracing::{debug, info, warn};
+
+use hardy_bpa::{
+    Bytes,
+    cla::{ClaAddress, CspAddress, Sink},
+};
+use hardy_bpv7::eid::NodeId;
+use tokio::task::{self, JoinHandle};
+
+pub struct Runtime {
+    pub csp_to_endpoint: HashMap<CspAddress, NodeId>,
+    polling_task: Option<JoinHandle<()>>,
+    cancel_polling_task: CancellationToken,
+}
+
+impl Runtime {
+    pub fn new(csp_to_endpoint: HashMap<CspAddress, NodeId>) -> Self {
+        Self {
+            csp_to_endpoint,
+            polling_task: None,
+            cancel_polling_task: CancellationToken::new(),
+        }
+    }
+
+    pub fn stop(&self) {
+        self.cancel_polling_task.cancel();
+    }
+
+    pub async fn start_inbound(&mut self, sink: Arc<dyn Sink>, mut inbound: InboundStream) {
+        let csp_to_endpoint = self.csp_to_endpoint.clone();
+
+        let csp_to_addr_iter = self.csp_to_endpoint.iter();
+        for csp_node in csp_to_addr_iter {
+            match sink
+                .add_peer(ClaAddress::Csp(*csp_node.0), &[csp_node.1.clone()])
+                .await
+            {
+                Ok(true) => debug!(
+                    "Registered CSP peer {}:{} as {}",
+                    csp_node.0.addr, csp_node.0.port, csp_node.1
+                ),
+                Ok(false) => debug!(
+                    "CSP peer {}:{} was already registered",
+                    csp_node.0.addr, csp_node.0.port
+                ),
+                Err(e) => warn!(
+                    "Failed to register CSP peer {}:{} as {}: {e}",
+                    csp_node.0.addr, csp_node.0.port, csp_node.1
+                ),
+            }
+        }
+        let cancel_token = self.cancel_polling_task.child_token();
+
+        info!("Starting polling task of inbound bundle stream");
+
+        let polling_task = task::spawn(async move {
+            loop {
+                debug!("Polling Hardy CSPCL inbound stream");
+                let next_bundle = tokio::select! {
+                    _ = cancel_token.cancelled() => break,
+                    next_bundle = inbound.try_next() => next_bundle,
+                };
+                let bundle = match next_bundle {
+                    Ok(bundle) => match bundle {
+                        Some(bundle) => bundle,
+                        None => {
+                            debug!("Hardy CSPCL inbound stream closed");
+                            break;
+                        }
+                    },
+                    Err(e) => {
+                        warn!("Error occured when receiving bundle: {}", e.to_string());
+                        continue;
+                    }
+                };
+                debug!(
+                    len = bundle.data.len(),
+                    "New bundle in inbound stream from {}:{}", bundle.src_addr, bundle.src_port
+                );
+                let bundle_data: Bytes = bundle.data.into();
+                let csp_peer_addr = CspAddress {
+                    addr: bundle.src_addr,
+                    port: bundle.src_port,
+                };
+                let node_id = csp_to_endpoint.get(&csp_peer_addr);
+                match sink
+                    .dispatch(bundle_data, node_id, Some(&ClaAddress::Csp(csp_peer_addr)))
+                    .await
+                {
+                    Ok(()) => info!(
+                        peer_node = node_id.map(|node_id| node_id.to_string()),
+                        "Dispatched inbound CSP bundle from {}:{} to BPA",
+                        csp_peer_addr.addr,
+                        csp_peer_addr.port
+                    ),
+                    Err(e) => warn!(
+                        "Failed to dispatch inbound CSP bundle from {}:{} to BPA: {e}",
+                        csp_peer_addr.addr, csp_peer_addr.port
+                    ),
+                }
+            }
+        });
+        self.polling_task = Some(polling_task);
+    }
+}

--- a/rust-bindings/hardy-cspcl/src/runtime.rs
+++ b/rust-bindings/hardy-cspcl/src/runtime.rs
@@ -1,4 +1,4 @@
-use cspcl_bindings::InboundStream;
+use cspcl_bindings::{CspAddress, InboundStream};
 use futures_util::TryStreamExt;
 use hardy_async::CancellationToken;
 use std::{collections::HashMap, sync::Arc};
@@ -6,7 +6,7 @@ use tracing::{debug, info, warn};
 
 use hardy_bpa::{
     Bytes,
-    cla::{ClaAddress, CspAddress, Sink},
+    cla::{ClaAddress, Sink},
 };
 use hardy_bpv7::eid::NodeId;
 use tokio::task::{self, JoinHandle};
@@ -35,8 +35,9 @@ impl Runtime {
 
         let csp_to_addr_iter = self.csp_to_endpoint.iter();
         for csp_node in csp_to_addr_iter {
+            let raw_addr: Bytes = Into::into(*csp_node.0);
             match sink
-                .add_peer(ClaAddress::Csp(*csp_node.0), &[csp_node.1.clone()])
+                .add_peer(ClaAddress::Private(raw_addr), &[csp_node.1.clone()])
                 .await
             {
                 Ok(true) => debug!(
@@ -88,7 +89,11 @@ impl Runtime {
                 };
                 let node_id = csp_to_endpoint.get(&csp_peer_addr);
                 match sink
-                    .dispatch(bundle_data, node_id, Some(&ClaAddress::Csp(csp_peer_addr)))
+                    .dispatch(
+                        bundle_data,
+                        node_id,
+                        Some(&ClaAddress::Private(csp_peer_addr.into())),
+                    )
                     .await
                 {
                     Ok(()) => info!(

--- a/rust-bindings/hardy-cspcl/src/transport.rs
+++ b/rust-bindings/hardy-cspcl/src/transport.rs
@@ -36,8 +36,8 @@ impl Transport {
             .map_err(Error::Send)
     }
 
-    pub async fn inbound_stream(&self) -> InboundStream {
-        self.cspcl.read().clone().inbound().await
+    pub fn inbound_stream(&self) -> InboundStream {
+        self.cspcl.read().clone().inbound()
     }
 
     pub fn cleanup(&self) {

--- a/rust-bindings/hardy-cspcl/src/transport.rs
+++ b/rust-bindings/hardy-cspcl/src/transport.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use cspcl_bindings::{Error as CspclError, InboundStream};
+use cspcl_bindings::{CspAddress, Error as CspclError, InboundStream};
 use hardy_async::sync::spin::RwLock;
 use tracing::debug;
 
@@ -27,13 +27,12 @@ impl Transport {
     pub async fn send_bundle(
         &self,
         payload: impl Into<Vec<u8>>,
-        addr: u8,
-        port: u8,
+        dest: CspAddress,
     ) -> Result<(), Error> {
-        debug!("Try sending bundle to: {}:{}", addr, port);
+        debug!("Try sending bundle to: {}:{}", dest.addr, dest.port);
         self.cspcl
             .write()
-            .send_bundle(&payload.into(), addr, port)
+            .send_bundle(&payload.into(), dest)
             .map_err(Error::Send)
     }
 

--- a/rust-bindings/hardy-cspcl/src/transport.rs
+++ b/rust-bindings/hardy-cspcl/src/transport.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use cspcl_bindings::{CspAddress, Error as CspclError, InboundStream};
-use hardy_async::sync::spin::RwLock;
 use tracing::debug;
 
 #[derive(Debug, thiserror::Error)]
@@ -16,11 +15,11 @@ pub enum Error {
 
 #[derive(Clone)]
 pub struct Transport {
-    cspcl: Arc<RwLock<cspcl_bindings::Cspcl>>,
+    cspcl: Arc<cspcl_bindings::Cspcl>,
 }
 
 impl Transport {
-    pub fn new(cspcl: Arc<RwLock<cspcl_bindings::Cspcl>>) -> Self {
+    pub fn new(cspcl: Arc<cspcl_bindings::Cspcl>) -> Self {
         Self { cspcl }
     }
 
@@ -31,17 +30,15 @@ impl Transport {
     ) -> Result<(), Error> {
         debug!("Try sending bundle to: {}:{}", dest.addr, dest.port);
         self.cspcl
-            .write()
             .send_bundle(&payload.into(), dest)
             .map_err(Error::Send)
     }
 
     pub fn inbound_stream(&self) -> InboundStream {
-        self.cspcl.read().clone().inbound()
+        Arc::clone(&self.cspcl).inbound()
     }
 
     pub fn cleanup(&self) {
-        let cspcl = self.cspcl.write();
-        drop(cspcl);
+        self.cspcl.close_rx_socket();
     }
 }

--- a/rust-bindings/hardy-cspcl/src/transport.rs
+++ b/rust-bindings/hardy-cspcl/src/transport.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+
+use cspcl_bindings::{Error as CspclError, InboundStream};
+use hardy_async::sync::spin::RwLock;
+use tracing::debug;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("transport init failed: {0}")]
+    Init(#[from] CspclError),
+    #[error("transport send failed: {0}")]
+    Send(#[source] CspclError),
+    #[error("transport receive failed: {0}")]
+    Recv(#[source] CspclError),
+}
+
+#[derive(Clone)]
+pub struct Transport {
+    cspcl: Arc<RwLock<cspcl_bindings::Cspcl>>,
+}
+
+impl Transport {
+    pub fn new(cspcl: Arc<RwLock<cspcl_bindings::Cspcl>>) -> Self {
+        Self { cspcl }
+    }
+
+    pub async fn send_bundle(
+        &self,
+        payload: impl Into<Vec<u8>>,
+        addr: u8,
+        port: u8,
+    ) -> Result<(), Error> {
+        debug!("Try sending bundle to: {}:{}", addr, port);
+        self.cspcl
+            .write()
+            .send_bundle(&payload.into(), addr, port)
+            .map_err(Error::Send)
+    }
+
+    pub async fn inbound_stream(&self) -> InboundStream {
+        self.cspcl.read().clone().inbound().await
+    }
+
+    pub fn cleanup(&self) {
+        let cspcl = self.cspcl.write();
+        drop(cspcl);
+    }
+}


### PR DESCRIPTION
## Description

Rust bindings expose a nice api to work with but it needs to be adapted for production use. As we want to interop with hardy I added `hardy-cspcl` inside the rust bindings.
The main work was to implement the CLA (convergence layer agent) trait from hardy. Later we will be able to use the CPSCLA over a grpc connection with an hardy-bpa (not in this PR).
Any hardy dependencies has been imported using git as the hardy repo does not publish packages on crates.io. This make relevant the add of test to be sure that hardy keeps the same api (not in this pr)

## Related Issue

None

## Type of Change

- [ ] Bug fix (non-breaking)
- [x ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup

## Checklist

- [ x] I have read [CONTRIBUTING.md](CONTRIBUTING.md).
- [ x] The stub-mode build passes: `cmake -DCSPC_REPO_DIR=/path/to/libcsp .. && make && ctest --verbose`
- [ ] New/changed C code is formatted with `clang-format`.
- [x ] New/changed Rust code passes `cargo fmt` and `cargo clippy`.
- [ ] Tests have been added or updated for the change.
- [ ] `CHANGELOG.md` has been updated under `[Unreleased]`.
