### PR TITLE
refactor(connection-handling): express send retry as a bounded loop

### DIFF
--- a/src/cspcl.c
+++ b/src/cspcl.c
@@ -572,28 +572,38 @@ cspcl_error_t cspcl_send_bundle(cspcl_t *cspcl, const uint8_t *bundle, size_t le
     return CSPCL_ERR_CONNECTION;
   }
 
-  /* Reuse pooled connection or open a new one on miss */
-  csp_conn_t *conn = cspcl_pool_get_or_create_locked(pool, dest_addr, dest_port);
-  if (conn == NULL) {
-    (void) cspcl_pool_unlock(pool);
-    return CSPCL_ERR_CONNECTION;
+  /* Send the bundle with one reconnect retry. A pooled connection may be
+   * stale (e.g. the peer restarted), so on failure we invalidate it and try
+   * a fresh connection once. Uses CSP's SFP to send, then waits for the
+   * receiver's application-level ack to confirm it actually arrived. */
+  int ret = CSP_ERR_TIMEDOUT;
+  bool conn_failed = false;
+
+  for (int attempt = 0; attempt < 2; attempt++) {
+    csp_conn_t *conn = cspcl_pool_get_or_create_locked(pool, dest_addr, dest_port);
+    if (conn == NULL) {
+      /* Only a first-attempt failure to obtain a connection is a hard
+       * connection error. If reconnect fails on the retry, fall through and
+       * report the original send failure (which stays retryable). */
+      if (attempt == 0) {
+        conn_failed = true;
+      }
+      break;
+    }
+
+    ret = cspcl_send_and_confirm(conn, bundle, len);
+    if (ret == CSP_ERR_NONE) {
+      break; /* Delivered and acked */
+    }
+
+    /* Stale or broken connection - invalidate so the next attempt (if any)
+     * reconnects, and so a dead connection never lingers in the pool. */
+    cspcl_pool_invalidate_locked(pool, dest_addr, dest_port);
   }
 
-  /* Use CSP's SFP to send the bundle, then wait for the receiver's
-   * application-level ack to confirm it actually arrived. */
-  int ret = cspcl_send_and_confirm(conn, bundle, len);
-
-  if (ret != CSP_ERR_NONE) {
-    /* The pooled connection may be stale (e.g. peer restarted). Reconnect
-     * and retry once. */
-    cspcl_pool_invalidate_locked(pool, dest_addr, dest_port);
-    conn = cspcl_pool_get_or_create_locked(pool, dest_addr, dest_port);
-    if (conn != NULL) {
-      ret = cspcl_send_and_confirm(conn, bundle, len);
-      if (ret != CSP_ERR_NONE) {
-        cspcl_pool_invalidate_locked(pool, dest_addr, dest_port);
-      }
-    }
+  if (conn_failed) {
+    (void) cspcl_pool_unlock(pool);
+    return CSPCL_ERR_CONNECTION;
   }
 
   if (cspcl_pool_unlock(pool) != 0) {


### PR DESCRIPTION
## What

Refactors the send-retry logic in `cspcl_send_bundle()` (previously lines 576–597 of `src/cspcl.c`) from hand-unrolled duplication into a bounded 2-iteration loop.

## Why

The old code wrote out the "send, and on failure invalidate + reconnect + send again" pattern twice, so `cspcl_send_and_confirm()`, `cspcl_pool_get_or_create_locked()`, and `cspcl_pool_invalidate_locked()` each appeared in two places. A maintainer had to visually diff the two blocks to confirm they matched. The loop keeps the retry policy in one place — changing "retry once" to "retry twice" is now a one-character edit.

## Behavior preserved

- A **first-attempt** failure to obtain a connection still returns `CSPCL_ERR_CONNECTION`.
- If reconnect fails on the **retry**, the original send failure is reported (which stays *retryable* per `cspcl_error_is_retryable`), matching the previous fall-through — handled via the `attempt == 0` check.
- The final failed attempt still invalidates the dead connection so it never lingers in the pool.

## Verification

- Builds clean (no new warnings).
- Test suites `test_cspcl`, `test_consolidation`, `test_ack_demo`, `test_ack_timeout_demo` pass.
- `test_cspcl_pool_integration` has 2 failing subtests (`stats.misses`) — **confirmed pre-existing**: they fail identically on the base commit (`8b96a9a`) because the ack-wait introduced in `feat(message-ack)` times out with no receiver in the unit test, and both old and new code do a second `get_or_create` (extra miss) on that failure. The refactor reproduces the exact same numbers, confirming behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)