### PR TITLE
feat(rust): A-SABR routing agent for Hardy (on A-SABR PR #66 API)

### DIFF
--- a/docs/api/rust.md
+++ b/docs/api/rust.md
@@ -14,7 +14,8 @@ The `cspcl` crate provides safe, idiomatic Rust bindings over the C library.
 
 ```toml
 [dependencies]
-cspcl = "0.1"
+cspcl = "0.4"
+futures = "0.3"
 ```
 
 For production use with real libcsp set the `CSP_PATH` environment variable before building:
@@ -35,57 +36,78 @@ pub struct Cspcl { /* ... */ }
 Owns the underlying `cspcl_t` instance. Resources are released automatically when
 the value is dropped.
 
-### `Cspcl::init`
+### `Cspcl::new`
 
 ```rust
-pub fn init(local_addr: u8) -> Result<Self, CspclerError>
+pub fn new(local: CspAddress, interface: Interface) -> Result<Self>
 ```
 
-Initialize CSPCL with the given local CSP node address.
-
-### `open_rx_socket`
-
-```rust
-pub fn open_rx_socket(&mut self) -> Result<(), CspclerError>
-```
-
-Bind the receive socket to the Bundle Protocol port. Call once before `recv_bundle`.
+Initialize CSPCL with the local CSP node address, CSP port, and interface.
 
 ### `send_bundle`
 
 ```rust
-pub fn send_bundle(&self, bundle: &[u8], dest_addr: u8) -> Result<(), CspclerError>
+pub fn send_bundle(&mut self, bundle: &[u8], dest: CspAddress) -> Result<()>
 ```
 
-Send a serialized BP7 bundle to `dest_addr`. Fragmentation via SFP is handled internally.
+Send a serialized BP7 bundle to `dest`. Fragmentation via SFP is handled internally.
 
-### `recv_bundle`
+### `inbound`
 
 ```rust
-pub fn recv_bundle(&self, timeout_ms: u32) -> Result<(Vec<u8>, u8), CspclerError>
+pub fn inbound(self) -> InboundStream
 ```
 
-Receive a complete bundle. Returns `(bundle_bytes, src_addr)`. Blocks until data
-arrives or `timeout_ms` elapses.
+Consume the handle and return a stream of inbound bundles.
+
+### `close_rx_socket`
+
+```rust
+pub fn close_rx_socket(self)
+```
+
+Cancel inbound receive work and close the receive socket.
 
 ---
 
-## Address Translation
+## Public Types
 
 ```rust
-// IPN / DTN endpoint to CSP address
-pub fn endpoint_to_addr(endpoint_id: &str) -> u8
+pub struct CspAddress {
+    pub addr: u8,
+    pub port: u8,
+}
 
-// CSP address to IPN endpoint string ("ipn:X.0")
-pub fn addr_to_endpoint(addr: u8) -> Result<String, CspclerError>
+pub struct Bundle {
+    pub data: Vec<u8>,
+    pub src_addr: u8,
+    pub src_port: u8,
+}
+
+pub enum Interface {
+    Zmq(String),
+    Can(String),
+    Loopback,
+}
 ```
+
+`CspAddress` also converts to and from two-byte `bytes::Bytes` values in
+`[addr, port]` order.
+
+### `InboundStream`
+
+```rust
+pub struct InboundStream { /* ... */ }
+```
+
+Implements `futures::Stream<Item = Result<Bundle>>`.
 
 ---
 
-## `CspclerError`
+## `Error`
 
 ```rust
-pub enum CspclerError {
+pub enum Error {
     InvalidParam,
     NoMemory,
     BundleTooLarge,
@@ -95,7 +117,15 @@ pub enum CspclerError {
     Sfp,
     NotInitialized,
     Connection,
-    Unknown(i32),
+    CspInit,
+    CspStackInit,
+    CspZmqhubInit,
+    CspCanInit,
+    CspCanNotSupported,
+    CspRouter,
+    PoolFull,
+    UnknownError(cspcl_sys::cspcl_error_t),
+    ParseAddress,
 }
 ```
 
@@ -106,24 +136,31 @@ Implements `std::error::Error` and `std::fmt::Display`.
 ## Example
 
 ```rust
-use cspcl::{Cspcl, CspclerError};
+use cspcl::{CspAddress, Cspcl, Error, Interface};
+use futures::StreamExt;
 
-fn transfer_bundle(bundle: &[u8], dest: u8) -> Result<(), CspclerError> {
-    let cspcl = Cspcl::init(1)?;
+fn transfer_bundle(bundle: &[u8], dest: CspAddress) -> Result<(), Error> {
+    let local = CspAddress { addr: 1, port: 10 };
+    let mut cspcl = Cspcl::new(local, Interface::Loopback)?;
     cspcl.send_bundle(bundle, dest)?;
     Ok(())
 }
 
-fn receive_loop() -> Result<(), CspclerError> {
-    let mut cspcl = Cspcl::init(1)?;
-    cspcl.open_rx_socket()?;
+async fn receive_loop() -> Result<(), Error> {
+    let local = CspAddress { addr: 1, port: 10 };
+    let cspcl = Cspcl::new(local, Interface::Loopback)?;
+    let mut inbound = cspcl.inbound();
 
-    loop {
-        match cspcl.recv_bundle(10_000) {
-            Ok((data, src)) => println!("Bundle from {}: {} bytes", src, data.len()),
-            Err(CspclerError::Timeout) => continue,
-            Err(e) => return Err(e),
-        }
+    while let Some(bundle) = inbound.next().await {
+        let bundle = bundle?;
+        println!(
+            "Bundle from {}:{}: {} bytes",
+            bundle.src_addr,
+            bundle.src_port,
+            bundle.data.len()
+        );
     }
+
+    Ok(())
 }
 ```

--- a/docs/api/rust.md
+++ b/docs/api/rust.md
@@ -47,7 +47,7 @@ Initialize CSPCL with the local CSP node address, CSP port, and interface.
 ### `send_bundle`
 
 ```rust
-pub fn send_bundle(&mut self, bundle: &[u8], dest: CspAddress) -> Result<()>
+pub fn send_bundle(&self, bundle: &[u8], dest: CspAddress) -> Result<()>
 ```
 
 Send a serialized BP7 bundle to `dest`. Fragmentation via SFP is handled internally.
@@ -55,15 +55,15 @@ Send a serialized BP7 bundle to `dest`. Fragmentation via SFP is handled interna
 ### `inbound`
 
 ```rust
-pub fn inbound(self) -> InboundStream
+pub fn inbound(self: Arc<Self>) -> InboundStream
 ```
 
-Consume the handle and return a stream of inbound bundles.
+Share the handle with a stream of inbound bundles.
 
 ### `close_rx_socket`
 
 ```rust
-pub fn close_rx_socket(self)
+pub fn close_rx_socket(&self)
 ```
 
 Cancel inbound receive work and close the receive socket.
@@ -138,18 +138,19 @@ Implements `std::error::Error` and `std::fmt::Display`.
 ```rust
 use cspcl::{CspAddress, Cspcl, Error, Interface};
 use futures::StreamExt;
+use std::sync::Arc;
 
 fn transfer_bundle(bundle: &[u8], dest: CspAddress) -> Result<(), Error> {
     let local = CspAddress { addr: 1, port: 10 };
-    let mut cspcl = Cspcl::new(local, Interface::Loopback)?;
+    let cspcl = Cspcl::new(local, Interface::Loopback)?;
     cspcl.send_bundle(bundle, dest)?;
     Ok(())
 }
 
 async fn receive_loop() -> Result<(), Error> {
     let local = CspAddress { addr: 1, port: 10 };
-    let cspcl = Cspcl::new(local, Interface::Loopback)?;
-    let mut inbound = cspcl.inbound();
+    let cspcl = Arc::new(Cspcl::new(local, Interface::Loopback)?);
+    let mut inbound = Arc::clone(&cspcl).inbound();
 
     while let Some(bundle) = inbound.next().await {
         let bundle = bundle?;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,23 +99,36 @@ Add the dependency:
 
 ```toml
 [dependencies]
-cspcl = "0.1"
+cspcl = "0.4"
+futures = "0.3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
 ```rust
-use cspcl::Cspcl;
+use cspcl::{CspAddress, Cspcl, Interface};
+use futures::StreamExt;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut node = Cspcl::init(1)?;
-    node.open_rx_socket()?;
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let local = CspAddress { addr: 1, port: 10 };
+    let mut node = Cspcl::new(local, Interface::Loopback)?;
 
     // Send
     let bundle: Vec<u8> = vec![/* BP7 bundle bytes */];
-    node.send_bundle(&bundle, 2)?;
+    let remote = CspAddress { addr: 2, port: 10 };
+    node.send_bundle(&bundle, remote)?;
 
-    // Receive (5 s timeout)
-    let (data, src_addr) = node.recv_bundle(5000)?;
-    println!("Received {} bytes from CSP addr {}", data.len(), src_addr);
+    // Receive from the inbound bundle stream.
+    let mut inbound = node.inbound();
+    while let Some(bundle) = inbound.next().await {
+        let bundle = bundle?;
+        println!(
+            "Received {} bytes from CSP {}:{}",
+            bundle.data.len(),
+            bundle.src_addr,
+            bundle.src_port
+        );
+    }
 
     Ok(())
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,11 +107,12 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```rust
 use cspcl::{CspAddress, Cspcl, Interface};
 use futures::StreamExt;
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let local = CspAddress { addr: 1, port: 10 };
-    let mut node = Cspcl::new(local, Interface::Loopback)?;
+    let node = Arc::new(Cspcl::new(local, Interface::Loopback)?);
 
     // Send
     let bundle: Vec<u8> = vec![/* BP7 bundle bytes */];
@@ -119,7 +120,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     node.send_bundle(&bundle, remote)?;
 
     // Receive from the inbound bundle stream.
-    let mut inbound = node.inbound();
+    let mut inbound = Arc::clone(&node).inbound();
     while let Some(bundle) = inbound.next().await {
         let bundle = bundle?;
         println!(

--- a/docs/superpowers/plans/2026-07-22-a-sabr-pr66-migration.md
+++ b/docs/superpowers/plans/2026-07-22-a-sabr-pr66-migration.md
@@ -1,0 +1,529 @@
+# A-SABR PR #66 Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adapt the `hardy-a-sabr` crate to the rebuilt A-SABR routing/pathfinding API from PR #66, migrating its internal time model from `f64` seconds to `i64` milliseconds.
+
+**Architecture:** Unchanged shape. `compute_first_hop` builds a fresh generativity-guarded `a_sabr::utils::Router` per call (SPSN + hybrid-parenting + SABR distance), routes a representative `Bundle` to one destination node, extracts the first-hop node id, and discards the router. The async `Scheduler` drives these queries at contact boundaries / on a safety tick and installs `RouteAction::Via` routes via the `RoutingSink`.
+
+**Tech Stack:** Rust (edition 2024, nightly toolchain — already in use), `a_sabr` (git dependency), `hardy-bpa`/`hardy-bpv7`, `tokio`, `tracing`.
+
+## Global Constraints
+
+- All A-SABR-facing time/duration values are **i64 milliseconds**; `rate` is **i64 bps**; `size` is **i64** (bundle volume). These replace the previous `f64` seconds model throughout `hardy-a-sabr`.
+- `NodeMapping.asabr_node_id` stays `u16`; cast to `a_sabr` `NodeID` (a `usize` wrapper) at the boundary via `(x as usize).into()`.
+- `ShadowEngineConfig` carries only `max_entries: usize`. Priority handling is the fixed `PRIO_COUNT = 1` const in the SPSN alias.
+- Destination type parameter is `a_sabr::multigraph::RoutableNodeRef` (unicast only; no multicast).
+- `a_sabr` is pinned to rev `16ffed523bf862ba770bf1b07adc8ee533066f1a` (A-SABR `main` HEAD, post-merge of PR #66).
+- Work happens on the current branch `feat/hardy-sabr-routing`. Commit after every task.
+- Node ids are assumed contiguous `0..N`; guarded by `debug_assert!` in `build_contact_plan`.
+
+---
+
+### Task 1: Pin the `a_sabr` dependency to the PR #66 merge
+
+**Files:**
+- Modify: `rust-bindings/hardy-a-sabr/Cargo.toml:12`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a resolvable `a_sabr` dependency exposing the new API (`a_sabr::utils::Router`, `a_sabr::pathfinding::top_level::aliases::SpsnHybridParenting`, `a_sabr::contact_plan::RealNode`, etc.).
+
+- [ ] **Step 1: Update the dependency line**
+
+In `rust-bindings/hardy-a-sabr/Cargo.toml`, change line 12 from:
+
+```toml
+a_sabr = { git = "https://github.com/DTN-MTP/A-SABR.git" }
+```
+
+to:
+
+```toml
+a_sabr = { git = "https://github.com/DTN-MTP/A-SABR.git", rev = "16ffed523bf862ba770bf1b07adc8ee533066f1a" }
+```
+
+- [ ] **Step 2: Refresh the lockfile for `a_sabr` only**
+
+Run: `cd rust-bindings && cargo update -p a_sabr --precise 16ffed523bf862ba770bf1b07adc8ee533066f1a`
+Expected: Cargo reports updating `a_sabr` from the old rev `1277e360…` to `16ffed52…` and pulls new transitive deps (`generativity`, `itertools`, `ringbuffer`, `replace_with`).
+
+- [ ] **Step 3: Confirm the dependency resolves and the new API is present**
+
+Run: `cd rust-bindings && cargo build -p hardy-a-sabr 2>&1 | head -40`
+Expected: The build **fails to compile** — but with errors about the *old* API in our source (e.g. `unresolved import a_sabr::routing`, `a_sabr::vertex`, `no variant lazy_get_for_unicast`, `Bundle` fields `source`/`destinations`). This confirms the new `a_sabr` is wired in and our code is what needs migrating. Errors about `a_sabr` internals failing to compile would instead indicate a toolchain problem — the toolchain is nightly (`rustc --version` shows `1.98.0-nightly`), which satisfies `a_sabr`'s edition-2024 + `Box::new_zeroed_slice` requirements.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/hugo/code/cspcl/cspcl-a-sabr
+git add rust-bindings/hardy-a-sabr/Cargo.toml rust-bindings/Cargo.lock
+git commit -m "build(hardy-a-sabr): pin a_sabr to PR #66 merge rev"
+```
+
+---
+
+### Task 2: Retype the time model to i64 milliseconds
+
+This task is a pure `f64 → i64` retype across the model files. The crate will **not** compile green at the end of this task — `engine.rs` still uses the old API and is fixed in Task 3. The checkpoint here is that the model files have the new types and `cargo build` no longer reports `f64`/`f64`-mismatch errors in these files (only the `engine.rs` API errors remain).
+
+**Files:**
+- Modify: `rust-bindings/hardy-a-sabr/src/topology.rs`
+- Modify: `rust-bindings/hardy-a-sabr/src/projection.rs:14-33` (the `RepresentativeBundle` struct + its `Default`) and `:46-52` (the `project_routes` signature)
+- Modify: `rust-bindings/hardy-a-sabr/src/refresh.rs:36` (`now` param)
+- Modify: `rust-bindings/hardy-a-sabr/src/scheduler.rs` (fields + `now`/`next_boundary_delay`)
+- Modify: `rust-bindings/hardy-a-sabr/src/router.rs` (field + builder)
+- Modify: `rust-bindings/hardy-a-sabr/src/config.rs:11` (`start_time`)
+
+**Interfaces:**
+- Produces:
+  - `topology::ContactWindow { tx_node_id: u16, rx_node_id: u16, start: i64, end: i64, rate: i64, delay: i64 }`
+  - `topology::TopologySnapshot::next_boundary_after(&self, now: i64) -> Option<i64>`
+  - `projection::RepresentativeBundle { size: i64, priority: i8, expiration_horizon: i64 }`
+  - `projection::project_routes(topology, engine_config, config, source: u16, now: i64) -> Result<Vec<ProjectedRoute>, ASABRError>`
+  - `scheduler::Scheduler::now(&self) -> i64`, `start_time: i64`
+  - `router::Router::with_start_time(self, start_time: i64) -> Self`, field `start_time: i64`
+  - `config::RuntimeConfig::start_time: i64`
+
+- [ ] **Step 1: Retype `ContactWindow` and `next_boundary_after` in `topology.rs`**
+
+Replace the `ContactWindow` struct definition with:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ContactWindow {
+    pub tx_node_id: u16,
+    pub rx_node_id: u16,
+    pub start: i64,
+    pub end: i64,
+    pub rate: i64,
+    pub delay: i64,
+}
+```
+
+Replace the `next_boundary_after` method body with:
+
+```rust
+    pub fn next_boundary_after(&self, now: i64) -> Option<i64> {
+        self.contacts
+            .iter()
+            .flat_map(|contact| [contact.start, contact.end])
+            .filter(|boundary| *boundary > now)
+            .min()
+    }
+```
+
+(`NodeMapping` and `hardy_eid_for` are unchanged.)
+
+- [ ] **Step 2: Retype `RepresentativeBundle` and `project_routes` in `projection.rs`**
+
+Replace the `RepresentativeBundle` struct and its `Default` impl with:
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RepresentativeBundle {
+    pub size: i64,
+    pub priority: i8,
+    pub expiration_horizon: i64,
+}
+
+impl Default for RepresentativeBundle {
+    fn default() -> Self {
+        Self {
+            size: 1,
+            priority: 0,
+            expiration_horizon: 3_600_000,
+        }
+    }
+}
+```
+
+Change the `project_routes` signature's `now` parameter from `now: f64` to `now: i64`. The function body is otherwise unchanged.
+
+In `refresh.rs`, change the `refresh_routes` signature's `now` parameter (line 36) from `now: f64` to `now: i64`. The body — which forwards `now` to `project_routes` — is unchanged.
+
+- [ ] **Step 3: Retype the clock in `scheduler.rs`**
+
+In `struct Scheduler`, change the field `start_time: f64` to `start_time: i64`. In `Scheduler::new`, change the parameter `start_time: f64` to `start_time: i64` (the struct-init line is unchanged).
+
+Replace the `now` method with:
+
+```rust
+    fn now(&self) -> i64 {
+        self.start_time + self.started_at.elapsed().as_millis() as i64
+    }
+```
+
+Replace `next_boundary_delay` with:
+
+```rust
+    fn next_boundary_delay(&self, now: i64) -> Option<Duration> {
+        self.topology
+            .next_boundary_after(now)
+            .map(|boundary| Duration::from_millis((boundary - now).max(0) as u64))
+    }
+```
+
+(`next_wakeup_delay`, which combines `next_boundary_delay` with `self.safety_tick` via `.min`, is unchanged — both are `Duration`.)
+
+- [ ] **Step 4: Retype `start_time` in `router.rs`**
+
+In `struct Router`, change `pub(crate) start_time: f64` to `pub(crate) start_time: i64`. In `Router::new`, change the initializer `start_time: 0.0` to `start_time: 0`. Change the builder to:
+
+```rust
+    pub fn with_start_time(mut self, start_time: i64) -> Self {
+        self.start_time = start_time;
+        self
+    }
+```
+
+- [ ] **Step 5: Retype `start_time` in `config.rs`**
+
+In `struct RuntimeConfig`, change `pub start_time: f64` to `pub start_time: i64`. (The `#[serde(default)]` attribute is unchanged; `i64` defaults to `0`.)
+
+- [ ] **Step 6: Confirm the model files type-check (engine errors expected)**
+
+Run: `cd rust-bindings && cargo build -p hardy-a-sabr 2>&1 | grep -E "topology.rs|projection.rs|refresh.rs|scheduler.rs|router.rs|config.rs" | head`
+Expected: **No** errors referencing these five files. Remaining errors all point at `engine.rs` (old A-SABR API) — that is fixed in Task 3.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/hugo/code/cspcl/cspcl-a-sabr
+git add rust-bindings/hardy-a-sabr/src/topology.rs rust-bindings/hardy-a-sabr/src/projection.rs rust-bindings/hardy-a-sabr/src/refresh.rs rust-bindings/hardy-a-sabr/src/scheduler.rs rust-bindings/hardy-a-sabr/src/router.rs rust-bindings/hardy-a-sabr/src/config.rs
+git commit -m "refactor(hardy-a-sabr): migrate time model to i64 milliseconds"
+```
+
+---
+
+### Task 3: Rewrite `engine.rs` for the new A-SABR API
+
+This task fixes the remaining compile errors and brings the crate green. It ends with a passing unit test for `compute_first_hop`.
+
+**Files:**
+- Modify (full rewrite of contents): `rust-bindings/hardy-a-sabr/src/engine.rs`
+- Test: appended `#[cfg(test)] mod tests` in `rust-bindings/hardy-a-sabr/src/engine.rs`
+
+**Interfaces:**
+- Consumes: `topology::TopologySnapshot`, `topology::NodeMapping`, `topology::ContactWindow`, `projection::RepresentativeBundle` (from Task 2).
+- Produces:
+  - `engine::ShadowEngineConfig { max_entries: usize }` (+ `Default` → `10`)
+  - `engine::build_contact_plan(&TopologySnapshot) -> Result<ContactPlan<NoManagement, EVLManager>, ASABRError>`
+  - `engine::compute_first_hop(topology, config, source: u16, destination: u16, now: i64, representative: &RepresentativeBundle) -> Result<Option<u16>, ASABRError>`
+
+- [ ] **Step 1: Write the failing test**
+
+Append this module to the end of `rust-bindings/hardy-a-sabr/src/engine.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::topology::{ContactWindow, NodeMapping, TopologySnapshot};
+    use hardy_bpv7::eid::NodeId;
+
+    fn node(asabr_node_id: u16, eid: &str) -> NodeMapping {
+        NodeMapping {
+            asabr_node_id,
+            hardy_node_id: eid.parse::<NodeId>().expect("valid node id"),
+        }
+    }
+
+    fn contact(tx: u16, rx: u16, start: i64, end: i64) -> ContactWindow {
+        ContactWindow {
+            tx_node_id: tx,
+            rx_node_id: rx,
+            start,
+            end,
+            rate: 1_000_000,
+            delay: 1,
+        }
+    }
+
+    #[test]
+    fn first_hop_follows_linear_plan() {
+        // 0 -> 1 -> 2, all contacts open for the whole horizon.
+        let topology = TopologySnapshot {
+            nodes: vec![node(0, "ipn:0.0"), node(1, "ipn:1.0"), node(2, "ipn:2.0")],
+            contacts: vec![contact(0, 1, 0, 100_000), contact(1, 2, 0, 100_000)],
+        };
+        let config = ShadowEngineConfig::default();
+        let representative = RepresentativeBundle::default();
+
+        let hop = compute_first_hop(&topology, &config, 0, 2, 0, &representative)
+            .expect("routing succeeds");
+        assert_eq!(hop, Some(1));
+    }
+
+    #[test]
+    fn no_path_returns_none() {
+        // 0 -> 1 only; node 2 is unreachable.
+        let topology = TopologySnapshot {
+            nodes: vec![node(0, "ipn:0.0"), node(1, "ipn:1.0"), node(2, "ipn:2.0")],
+            contacts: vec![contact(0, 1, 0, 100_000)],
+        };
+        let config = ShadowEngineConfig::default();
+        let representative = RepresentativeBundle::default();
+
+        let hop = compute_first_hop(&topology, &config, 0, 2, 0, &representative)
+            .expect("routing succeeds");
+        assert_eq!(hop, None);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails to compile**
+
+Run: `cd rust-bindings && cargo test -p hardy-a-sabr first_hop 2>&1 | head -30`
+Expected: FAIL — compile errors from the old A-SABR API still present in the non-test part of `engine.rs`.
+
+- [ ] **Step 3: Replace the non-test part of `engine.rs`**
+
+Replace everything in `rust-bindings/hardy-a-sabr/src/engine.rs` *above* the `#[cfg(test)] mod tests` block with:
+
+```rust
+use a_sabr::{
+    bundle::Bundle,
+    contact::{Contact, ContactInfo},
+    contact_manager::legacy::evl::EVLManager,
+    contact_plan::{ContactPlan, RealNode},
+    errors::ASABRError,
+    multigraph::RoutableNodeRef,
+    node::{Node, NodeInfo},
+    node_manager::none::NoManagement,
+    pathfinding::top_level::aliases::SpsnHybridParenting,
+    utils::{Router, make_guard},
+};
+
+use crate::{projection::RepresentativeBundle, topology::TopologySnapshot};
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ShadowEngineConfig {
+    pub max_entries: usize,
+}
+
+impl Default for ShadowEngineConfig {
+    fn default() -> Self {
+        Self { max_entries: 10 }
+    }
+}
+
+pub fn build_contact_plan(
+    topology: &TopologySnapshot,
+) -> Result<ContactPlan<NoManagement, EVLManager>, ASABRError> {
+    let mut nodes = topology
+        .nodes
+        .iter()
+        .filter_map(|node| {
+            Node::try_new(
+                NodeInfo {
+                    id: (node.asabr_node_id as usize).into(),
+                    name: node.hardy_node_id.to_string().into(),
+                    excluded: false,
+                },
+                NoManagement {},
+            )
+            .map(|inode| (node.asabr_node_id, RealNode::Inode(inode)))
+        })
+        .collect::<Vec<_>>();
+
+    nodes.sort_by_key(|(id, _)| *id);
+
+    debug_assert!(
+        nodes
+            .iter()
+            .enumerate()
+            .all(|(index, (id, _))| index as u16 == *id),
+        "asabr_node_id values must be contiguous starting at 0"
+    );
+
+    let realnodes = nodes.into_iter().map(|(_, node)| node).collect::<Vec<_>>();
+
+    let contacts = topology
+        .contacts
+        .iter()
+        .filter_map(|contact| {
+            Contact::try_new(
+                ContactInfo::new(
+                    (contact.tx_node_id as usize).into(),
+                    (contact.rx_node_id as usize).into(),
+                    contact.start,
+                    contact.end,
+                ),
+                EVLManager::new(contact.rate, contact.delay),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    Ok(ContactPlan::new(realnodes, Vec::new(), contacts))
+}
+
+pub fn compute_first_hop(
+    topology: &TopologySnapshot,
+    config: &ShadowEngineConfig,
+    source: u16,
+    destination: u16,
+    now: i64,
+    representative: &RepresentativeBundle,
+) -> Result<Option<u16>, ASABRError> {
+    let contact_plan = build_contact_plan(topology)?;
+
+    make_guard!(id);
+    let mut router = Router::<_, _, SpsnHybridParenting<1, _, _, _>, RoutableNodeRef>::build(
+        id,
+        contact_plan,
+        (config.max_entries, ()),
+    )?;
+
+    let bundle = Bundle {
+        priority: representative.priority,
+        size: representative.size,
+        expiration: now + representative.expiration_horizon,
+    };
+
+    let Some(source_ref) = router.node_id_ref((source as usize).into())?.internal() else {
+        return Ok(None);
+    };
+    let destination_ref = router
+        .node_id_ref((destination as usize).into())?
+        .routable()?;
+
+    let output = router.route(destination_ref, now, source_ref, &bundle, None)?;
+
+    Ok(output.map(|(_path, first_hop)| {
+        usize::from(
+            first_hop
+                .rx_node
+                .internal()
+                .expect("A-SABR first-hop rx_node is always an internal node"),
+        ) as u16
+    }))
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd rust-bindings && cargo test -p hardy-a-sabr 2>&1 | tail -20`
+Expected: PASS — `first_hop_follows_linear_plan` and `no_path_returns_none` both pass; crate compiles with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/hugo/code/cspcl/cspcl-a-sabr
+git add rust-bindings/hardy-a-sabr/src/engine.rs
+git commit -m "refactor(hardy-a-sabr): route via new A-SABR utils::Router API"
+```
+
+---
+
+### Task 4: Update the sample server config to i64 milliseconds
+
+**Files:**
+- Modify: `rust-bindings/hardy-a-sabr-server/examples/a-sabr-router.yaml`
+
+**Interfaces:**
+- Consumes: the `config::RuntimeConfig` / `engine::ShadowEngineConfig` / `topology`/`projection` shapes from Tasks 2–3.
+- Produces: a YAML config that deserializes cleanly under the new types.
+
+- [ ] **Step 1: Rewrite the sample config**
+
+Replace the entire contents of `rust-bindings/hardy-a-sabr-server/examples/a-sabr-router.yaml` with (times in ms, `start`/`end`/`delay` scaled ×1000, `rate` unchanged as bps, `expiration_horizon` = 1 h in ms, and the removed `engine` sub-keys dropped):
+
+```yaml
+grpc_addr: "http://[::1]:51051"
+agent_name: "a-sabr"
+
+runtime:
+  source: 0
+  start_time: 0
+  safety_tick_secs: 10
+
+  engine:
+    max_entries: 10
+
+  topology:
+    nodes:
+      - asabr_node_id: 0
+        hardy_node_id: "ipn:0.1.0"
+      - asabr_node_id: 1
+        hardy_node_id: "ipn:1.2.0"
+    contacts:
+      - tx_node_id: 0
+        rx_node_id: 1
+        start: 0
+        end: 60000
+        rate: 1000000
+        delay: 1000
+
+  projection:
+    bundle:
+      size: 1
+      priority: 0
+      expiration_horizon: 3600000
+    destinations:
+      - pattern: "ipn:1.2.*"
+        asabr_destination: 1
+        route_priority: 100
+```
+
+- [ ] **Step 2: Verify the server builds and the config parses**
+
+Run: `cd rust-bindings && cargo build -p hardy-a-sabr-server 2>&1 | tail -10`
+Expected: PASS — the server compiles against the migrated crate. (Config parsing is exercised by `serde_yaml` at runtime; a compile is sufficient for this task since the server has no config-parse unit test.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/hugo/code/cspcl/cspcl-a-sabr
+git add rust-bindings/hardy-a-sabr-server/examples/a-sabr-router.yaml
+git commit -m "docs(hardy-a-sabr-server): update sample config to i64 milliseconds"
+```
+
+---
+
+### Task 5: Full workspace verification
+
+**Files:** none (verification only).
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Build the whole workspace**
+
+Run: `cd rust-bindings && cargo build 2>&1 | tail -15`
+Expected: PASS — all crates (`cspcl-sys`, `cspcl`, `hardy-cspcl`, `hardy-a-sabr`, `hardy-a-sabr-server`) compile.
+
+- [ ] **Step 2: Run all tests**
+
+Run: `cd rust-bindings && cargo test 2>&1 | tail -20`
+Expected: PASS — including the two `engine.rs` tests from Task 3.
+
+- [ ] **Step 3: Run clippy on the migrated crate**
+
+Run: `cd rust-bindings && cargo clippy -p hardy-a-sabr -p hardy-a-sabr-server 2>&1 | tail -20`
+Expected: No errors. Warnings that predate this work (if any) are acceptable; new warnings introduced by the migration should be fixed.
+
+- [ ] **Step 4: Verify the serde feature also builds**
+
+Run: `cd rust-bindings && cargo build -p hardy-a-sabr --features serde 2>&1 | tail -10`
+Expected: PASS — the `Serialize`/`Deserialize` derives on the retyped structs compile.
+
+- [ ] **Step 5: Final commit (only if clippy fixes were made)**
+
+```bash
+cd /home/hugo/code/cspcl/cspcl-a-sabr
+git add -A rust-bindings/hardy-a-sabr rust-bindings/hardy-a-sabr-server
+git commit -m "chore(hardy-a-sabr): clippy cleanup after PR #66 migration"
+```
+
+(Skip this commit if Steps 1–4 produced no changes.)
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** engine rewrite (Task 3), i64 model incl. topology/projection/scheduler/router/config (Task 2), `ShadowEngineConfig`→`max_entries` (Task 3), `asabr_node_id: u16` retained (Task 2/3), dependency pin (Task 1), sample-config update (Task 4), node-id `debug_assert!` (Task 3), tests + workspace build/test/clippy/serde (Tasks 3, 5). Risk #1 (toolchain) is resolved — nightly confirmed in Task 1 Step 3. Risk #2 (`make_guard!` re-export) is exercised the moment Task 3 compiles; if `use a_sabr::utils::make_guard;` fails to resolve, add `generativity = "1.2"` to `hardy-a-sabr/Cargo.toml` `[dependencies]` and import `use generativity::make_guard;` instead. Risk #3 (first-hop extraction) is pinned by `first_hop_follows_linear_plan`.
+- **Placeholder scan:** none — every code step contains full content.
+- **Type consistency:** `compute_first_hop(topology, config, source: u16, destination: u16, now: i64, representative: &RepresentativeBundle) -> Result<Option<u16>, ASABRError>` and `ShadowEngineConfig { max_entries: usize }` are used identically in the Task 3 code and the Task 3 tests; `now: i64` is consistent across `project_routes`, `Scheduler::now`, and `compute_first_hop`.

--- a/docs/superpowers/specs/2026-07-22-a-sabr-pr66-migration-design.md
+++ b/docs/superpowers/specs/2026-07-22-a-sabr-pr66-migration-design.md
@@ -1,0 +1,108 @@
+# A-SABR PR #66 API migration — design
+
+**Date:** 2026-07-22
+**Crate:** `rust-bindings/hardy-a-sabr` (+ `hardy-a-sabr-server` config files)
+**Upstream:** [DTN-MTP/A-SABR PR #66](https://github.com/DTN-MTP/A-SABR/pull/66) (merged to `main`)
+
+## Goal
+
+Adapt `hardy-a-sabr` to the rebuilt A-SABR routing/pathfinding public interface introduced by PR #66. The crate's role is unchanged: build an ephemeral "shadow" contact-graph per query, compute the first hop toward each projected destination, and install the results as `RouteAction::Via` routes through the async `Scheduler`. Only the A-SABR call surface and the numeric time model change.
+
+## Summary of upstream API changes
+
+The A-SABR crate moved to a workspace layout (package `a_sabr` now lives in the `asabr/` subdirectory), `edition = "2024"`, and `#![no_std]` (using `alloc`). The routing surface was rebuilt:
+
+| Old (current `hardy-a-sabr`) | New (PR #66) |
+|---|---|
+| `a_sabr::routing::Router`, `a_sabr::routing::aliases::SpsnHybridParenting` | `a_sabr::utils::Router`, `a_sabr::pathfinding::top_level::aliases::SpsnHybridParenting` — alias gains a `PRIO_COUNT` const generic and a destination type param `D` |
+| `a_sabr::vertex::Vertex` (`INode`/`ENode`/`VNode`) | **removed** → `a_sabr::contact_plan::RealNode` (`Inode`/`Enode`) + `a_sabr::multigraph` node refs |
+| `Bundle { source, destinations, priority, size, expiration }` | `Bundle { priority, size, expiration }` — `source` and `destinations` removed; source & destination are passed to `route()` instead |
+| `TreeCache::new(check_size, check_priority, max_entries)` built by hand | built implicitly from pathfinder args `(max_entries, ())`; `check_priority` → the `PRIO_COUNT` const; `check_size` knob removed |
+| `router.route(source_u16, &bundle, now, &excluded)` → `out.lazy_get_for_unicast(dest)` → `contact.borrow().info.rx_node_id` | `router.route(dest_ref, now, source_ref, &bundle, prune)` → `Option<(PathIterator, PathFragment)>`; the returned `PathFragment` is the **first hop**, `frag.rx_node` is its receiving node |
+| `ContactPlan::new(vertices, contacts, None)` | `ContactPlan::new(realnodes, vnodes, contacts)`; `Contact::try_new(...)` now returns `Option<(Contact, tx_idx, rx_idx)>` — the exact tuple `contacts` wants |
+| `EVLManager::new(rate: f64, delay: f64)` | `EVLManager::new(rate: i64, delay: i64)` (`DataRate` / `Duration`) |
+
+Two structural shifts drive the design:
+
+1. **Generativity lifetime `'id`.** `Multigraph`/`Router` carry an invariant lifetime bound to a `make_guard!` stack token, so they cannot be stored in a struct field or held across `.await` — they must be built, used, and dropped inside one stack frame. `compute_first_hop` already follows this "build → route → discard" pattern, so no structural rework is required.
+
+2. **Numeric types `f64` → `i64`.** `Date`, `Duration`, `Volume`, `DataRate` are all `i64` now (recommended unit: milliseconds / bytes / bps). `NodeID` is a `usize` wrapper (was `u16`). We migrate the entire `hardy-a-sabr` model to **i64 milliseconds** to match natively, with no conversion layer.
+
+## Architecture
+
+Unchanged. Per `compute_first_hop` call: build a fresh `ContactPlan` from the `TopologySnapshot`, wrap it in a generativity-guarded `Router` using the SPSN / hybrid-parenting / SABR-distance pathfinder, route a representative `Bundle` to a single destination node, extract the first-hop node id, then discard the router. The `Scheduler` drives these queries at contact boundaries and on a safety tick, diffs the resulting routes, and installs them via the `RoutingSink`. `route()` mutates (schedules tx on) the graph, which is harmless because the graph is rebuilt and discarded on every call — this preserves the existing shadow semantics.
+
+## Component-level changes
+
+### `engine.rs` (core rewrite)
+
+- **Imports:** add `utils::{Router, make_guard}`, `pathfinding::top_level::aliases::SpsnHybridParenting`, `contact_plan::{ContactPlan, RealNode}`, `multigraph::RoutableNodeRef`. Remove `vertex::Vertex`, `routing::*`, `route_storage::cache::TreeCache`, `contact::*` stays.
+- **`build_contact_plan`:** produce `Vec<RealNode<NoManagement>>` via `RealNode::Inode(Node::try_new(NodeInfo { id: (asabr_node_id as usize).into(), name: hardy_node_id.to_string().into(), excluded: false }, NoManagement {}))`, sorted by `asabr_node_id`. `vnodes` is empty. Contacts: `Contact::try_new(ContactInfo::new((tx as usize).into(), (rx as usize).into(), start, end), EVLManager::new(rate, delay))` — `filter_map` yields the `(Contact, tx_idx, rx_idx)` tuples directly. Return `ContactPlan::new(realnodes, Vec::new(), contacts)`.
+- **Delete** `new_route_cache`, `build_shadow_router`, and the `ShadowRouter` type alias.
+- **`compute_first_hop(topology, config, source: u16, destination: u16, now: i64, representative) -> Result<Option<u16>, ASABRError>`:**
+  1. `let contact_plan = build_contact_plan(topology)?;`
+  2. `make_guard!(id);`
+  3. `let mut router = Router::<_, _, SpsnHybridParenting<1, _, _, _>, RoutableNodeRef>::build(id, contact_plan, (config.max_entries, ()))?;`
+  4. `let bundle = Bundle { priority: representative.priority, size: representative.size, expiration: now + representative.expiration_horizon };`
+  5. Resolve `source_ref` via `router.node_id_ref((source as usize).into())?.internal()`; return `Ok(None)` if the source node is not internal.
+  6. Resolve `dest_ref` via `router.node_id_ref((destination as usize).into())?.routable()?`.
+  7. `let out = router.route(dest_ref, now, source_ref, &bundle, None)?;`
+  8. `Ok(out.map(|(_, first_hop)| usize::from(first_hop.rx_node.internal().expect("first hop rx_node is internal")) as u16))`.
+- **`ShadowEngineConfig`** reduces to `{ max_entries: usize }`. `check_size` is removed (no API equivalent); `check_priority` is removed and replaced by the fixed `PRIO_COUNT = 1` const in the alias (matching the old `false` default). `Default` keeps `max_entries: 10`.
+
+### `topology.rs`
+- `ContactWindow`: `start: i64`, `end: i64`, `delay: i64` (ms), `rate: i64` (bps).
+- `NodeMapping.asabr_node_id`: **stays `u16`** (compact domain id, cast to `NodeID` at the A-SABR boundary).
+- `next_boundary_after(now: i64) -> Option<i64>` (integer comparison, `min` instead of `total_cmp`).
+
+### `projection.rs`
+- `RepresentativeBundle { size: i64, expiration_horizon: i64 }`; `Default` → `size: 1`, `priority: 0`, `expiration_horizon: 3_600_000` (1 hour in ms).
+- `project_routes(..., now: i64)`.
+
+### `scheduler.rs`
+- `start_time: i64` (ms).
+- `now() = self.start_time + self.started_at.elapsed().as_millis() as i64`.
+- `next_boundary_delay`: `Duration::from_millis((boundary - now).max(0) as u64)`.
+- `safety_tick` stays a `std::time::Duration` (wall-clock sleep budget).
+
+### `router.rs`
+- `start_time: f64 → i64`; `with_start_time(i64)`. `safety_tick: Duration` unchanged.
+
+### `config.rs`
+- `RuntimeConfig.start_time: f64 → i64`. `safety_tick_secs: u64` unchanged (still a real-seconds wall-clock budget).
+
+### `hardy-a-sabr-server`
+- No Rust changes expected — it deserializes `RuntimeConfig` from YAML. **Existing/sample YAML config files must be updated** so contact times, delays, `expiration_horizon`, and `start_time` are i64 milliseconds (and `rate` is i64 bps). Any sample configs committed in the repo are updated as part of this work.
+
+### `hardy-a-sabr/Cargo.toml`
+- Pin `a_sabr` to a specific merged-`main` `rev` for reproducibility (currently unpinned). The `git` dependency by package name `a_sabr` still resolves despite the `asabr/` subdirectory move.
+- Add `generativity` as a direct dependency **only if** the `make_guard!` re-export through `a_sabr::utils` fails to resolve at the call site.
+
+## Invariants & assumptions
+
+- **Node-id contiguity:** `asabr_node_id` values are assumed to be `0..N` contiguous, so a node's position in the id-sorted `realnodes` vector equals its id. `Contact::try_new` derives contact endpoint indices from raw node ids, which is only correct under this assumption. This assumption is already present in the current code; it is preserved and guarded with a `debug_assert!` in `build_contact_plan`.
+- **Unit convention:** all A-SABR-facing time/duration values are milliseconds; volumes are in the same arbitrary unit the caller uses for bundle `size`; rates are bps. The convention only needs to be internally consistent across the contact plan, bundle, and `now`.
+
+## Error handling
+
+- `compute_first_hop` continues to return `Result<Option<u16>, ASABRError>`: `Err` on A-SABR construction/routing failure, `Ok(None)` when no path exists (including source == destination, which `route()` reports as no first hop), `Ok(Some(hop))` otherwise.
+- `project_routes` propagates `ASABRError` and skips destinations with no first hop or no reverse EID mapping, as today.
+- The `Scheduler` logs and swallows refresh/withdraw errors via `tracing::warn!`, unchanged.
+
+## Risks
+
+1. **Toolchain.** A-SABR is now `edition = "2024"` (Rust ≥ 1.85) and `destination.rs` uses `Box::new_zeroed_slice` (nightly `new_zeroed_alloc`). The **first implementation step is a trial `cargo build`** against the pinned dependency to surface any toolchain/nightly requirement (e.g. a `rust-toolchain.toml`) before writing migration code.
+2. **`make_guard!` re-export.** If the macro doesn't resolve through `a_sabr::utils`, fall back to a direct `generativity` dependency (see Cargo.toml note).
+3. **First-hop extraction correctness.** The returned `PathFragment` is the fragment immediately after the source (verified against `PathIterator::commit` and the `inter-regional_routing` example). A unit test pins this behaviour.
+
+## Testing
+
+- `cargo build` and `cargo test` for the whole `rust-bindings` workspace against the real A-SABR dependency.
+- A `compute_first_hop` unit test over a small 3-node linear contact plan (`0 → 1 → 2`) asserting the next hop from `0` toward `2` is `1`, and that an unreachable destination yields `Ok(None)`.
+- Verify `hardy-a-sabr-server` still loads its (updated) YAML config.
+
+## Out of scope
+
+- Multicast (`Dest::AllNodes` / anycast) — not implemented upstream for `NoManagement`; we route unicast to a single `RoutableNodeRef` destination only.
+- Any change to the scheduler's contact-boundary/safety-tick logic beyond the `f64 → i64` retype.
+- Virtual nodes / external nodes in the topology model.

--- a/rust-bindings/Cargo.lock
+++ b/rust-bindings/Cargo.lock
@@ -3,6 +3,19 @@
 version = 4
 
 [[package]]
+name = "a_sabr"
+version = "0.1.0"
+source = "git+https://github.com/DTN-MTP/A-SABR.git#1277e360f2d61a593c336c6f6eb2e583758d7580"
+dependencies = [
+ "cfg-if",
+ "derivative",
+ "replace_with",
+ "serde",
+ "serde_json",
+ "static_assertions",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +340,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +572,7 @@ dependencies = [
 name = "hardy-a-sabr"
 version = "0.1.0"
 dependencies = [
+ "a_sabr",
  "hardy-async",
  "hardy-bpa",
  "hardy-bpv7",
@@ -716,6 +741,12 @@ checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -972,6 +1003,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "replace_with"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1054,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1081,6 +1131,12 @@ checksum = "1527984ca054dfca79333baec451042863f485fbee01b7bf6d911de915cac865"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"
@@ -1407,3 +1463,9 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/rust-bindings/Cargo.lock
+++ b/rust-bindings/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "hardy-bpa",
  "hardy-bpv7",
  "hardy-eid-patterns",
+ "serde",
  "tokio",
  "tracing",
 ]

--- a/rust-bindings/Cargo.lock
+++ b/rust-bindings/Cargo.lock
@@ -5,12 +5,14 @@ version = 4
 [[package]]
 name = "a_sabr"
 version = "0.1.0"
-source = "git+https://github.com/DTN-MTP/A-SABR.git#1277e360f2d61a593c336c6f6eb2e583758d7580"
+source = "git+https://github.com/DTN-MTP/A-SABR.git?rev=16ffed523bf862ba770bf1b07adc8ee533066f1a#16ffed523bf862ba770bf1b07adc8ee533066f1a"
 dependencies = [
  "cfg-if",
  "derivative",
+ "generativity",
+ "itertools 0.14.0",
  "replace_with",
- "serde",
+ "ringbuffer",
  "serde_json",
  "static_assertions",
 ]
@@ -221,7 +223,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -634,6 +636,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "generativity"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c81fb5260e37854d09d5c87183309fd8c555b75289427884b25660bc87a85e"
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1049,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,7 +1337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -1341,7 +1358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -1456,6 +1473,12 @@ name = "replace_with"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
+
+[[package]]
+name = "ringbuffer"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b0b88a509053cbfd535726dcaaceee631313cef981266119527a1d110f6d2b"
 
 [[package]]
 name = "rustc-hash"

--- a/rust-bindings/Cargo.lock
+++ b/rust-bindings/Cargo.lock
@@ -300,7 +300,6 @@ dependencies = [
  "futures",
  "tokio",
  "tokio-util",
- "trace",
  "tracing",
 ]
 
@@ -578,6 +577,7 @@ dependencies = [
  "hardy-bpv7",
  "hardy-eid-patterns",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1254,17 +1254,6 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "trace"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad0c048e114d19d1140662762bfdb10682f3bc806d8be18af846600214dd9af"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/rust-bindings/Cargo.lock
+++ b/rust-bindings/Cargo.lock
@@ -551,6 +551,7 @@ dependencies = [
  "hardy-async",
  "hardy-bpa",
  "hardy-bpv7",
+ "hardy-eid-patterns",
 ]
 
 [[package]]

--- a/rust-bindings/Cargo.lock
+++ b/rust-bindings/Cargo.lock
@@ -3,6 +3,62 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr",
+ "ghash",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "aes-kw"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ac571010bd60765c56085a4f1d412012a9be2663b1a2f2b19b49318653fd0d"
+dependencies = [
+ "aes 0.9.1",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +66,44 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
@@ -28,26 +122,41 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex 2.0.1",
@@ -69,6 +178,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +206,76 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -100,16 +299,97 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.15.0"
+name = "ctr"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures"
@@ -167,7 +447,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -200,10 +480,221 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
+name = "hardy-async"
+version = "0.1.0"
+source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+dependencies = [
+ "async-trait",
+ "flume",
+ "futures",
+ "spin 0.12.0",
+ "time",
+ "tokio",
+ "tokio-util",
+ "trace-err",
+ "tracing",
+]
+
+[[package]]
+name = "hardy-bpa"
+version = "0.1.0"
+source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+dependencies = [
+ "arc-swap",
+ "base64",
+ "bytes",
+ "foldhash",
+ "futures",
+ "hardy-async",
+ "hardy-bpv7",
+ "hardy-cbor",
+ "hardy-eid-patterns",
+ "hashbrown",
+ "lru",
+ "metrics",
+ "rand",
+ "serde",
+ "thiserror",
+ "time",
+ "trace-err",
+ "tracing",
+]
+
+[[package]]
+name = "hardy-bpv7"
+version = "0.5.0"
+source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+dependencies = [
+ "aes-gcm",
+ "aes-kw",
+ "base64",
+ "crc",
+ "hardy-cbor",
+ "hashbrown",
+ "hmac",
+ "percent-encoding",
+ "portable-atomic",
+ "rand",
+ "serde",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "time",
+ "winnow",
+ "zeroize",
+]
+
+[[package]]
+name = "hardy-cbor"
+version = "1.0.0"
+source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+dependencies = [
+ "half",
+ "num-traits",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "hardy-cspcl"
+version = "0.1.0"
+dependencies = [
+ "cspcl",
+ "futures-util",
+ "hardy-async",
+ "hardy-bpa",
+ "hardy-bpv7",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hardy-eid-patterns"
+version = "0.3.0"
+source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+dependencies = [
+ "glob",
+ "hardy-bpv7",
+ "percent-encoding",
+ "serde",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "itertools"
@@ -215,10 +706,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.182"
+name = "js-sys"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -231,22 +732,64 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.29"
+name = "libm"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
 
 [[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "nom"
@@ -259,16 +802,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.16"
+name = "opaque-debug"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -277,7 +872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -291,18 +886,55 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.3"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -323,15 +955,68 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest",
+]
 
 [[package]]
 name = "shlex"
@@ -346,10 +1031,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1527984ca054dfca79333baec451042863f485fbee01b7bf6d911de915cac865"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -364,13 +1089,63 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "time"
+version = "0.3.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -379,8 +1154,12 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "libc",
+ "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
+ "windows-sys",
 ]
 
 [[package]]
@@ -391,7 +1170,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -403,6 +1182,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -416,6 +1196,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "trace-err"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f74d0870c543d68ea83cd81d58e03ef343bfc3a98ce7173b8085cd3b09a29a29"
+dependencies = [
+ "tracing",
 ]
 
 [[package]]
@@ -437,7 +1226,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -450,13 +1239,159 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]

--- a/rust-bindings/Cargo.lock
+++ b/rust-bindings/Cargo.lock
@@ -545,6 +545,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hardy-a-sabr"
+version = "0.1.0"
+dependencies = [
+ "hardy-async",
+ "hardy-bpa",
+ "hardy-bpv7",
+]
+
+[[package]]
 name = "hardy-async"
 version = "0.1.0"
 source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"

--- a/rust-bindings/Cargo.lock
+++ b/rust-bindings/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
 name = "cspcl"
 version = "0.4.0"
 dependencies = [
+ "bytes",
  "cspcl-sys",
  "futures",
  "tokio",
@@ -546,7 +547,7 @@ dependencies = [
 [[package]]
 name = "hardy-async"
 version = "0.1.0"
-source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
 dependencies = [
  "async-trait",
  "flume",
@@ -562,7 +563,7 @@ dependencies = [
 [[package]]
 name = "hardy-bpa"
 version = "0.1.0"
-source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
 dependencies = [
  "arc-swap",
  "base64",
@@ -587,7 +588,7 @@ dependencies = [
 [[package]]
 name = "hardy-bpv7"
 version = "0.5.0"
-source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
 dependencies = [
  "aes-gcm",
  "aes-kw",
@@ -611,7 +612,7 @@ dependencies = [
 [[package]]
 name = "hardy-cbor"
 version = "1.0.0"
-source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
 dependencies = [
  "half",
  "num-traits",
@@ -623,6 +624,7 @@ dependencies = [
 name = "hardy-cspcl"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "cspcl",
  "futures-util",
  "hardy-async",
@@ -637,7 +639,7 @@ dependencies = [
 [[package]]
 name = "hardy-eid-patterns"
 version = "0.3.0"
-source = "git+https://github.com/hugoponthieu/hardy.git?branch=cspcl-patches#78c836bd85286bb40797db36bf9f605217410d8e"
+source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
 dependencies = [
  "glob",
  "hardy-bpv7",

--- a/rust-bindings/Cargo.lock
+++ b/rust-bindings/Cargo.lock
@@ -577,6 +577,7 @@ dependencies = [
  "hardy-bpa",
  "hardy-bpv7",
  "hardy-eid-patterns",
+ "tokio",
 ]
 
 [[package]]

--- a/rust-bindings/Cargo.lock
+++ b/rust-bindings/Cargo.lock
@@ -17,23 +17,12 @@ dependencies = [
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.1.7",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher 0.4.4",
- "cpufeatures 0.2.17",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -42,20 +31,20 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cipher 0.5.2",
+ "cipher",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
- "aes 0.8.4",
- "cipher 0.4.4",
+ "aes",
+ "cipher",
  "ctr",
  "ghash",
  "subtle",
@@ -68,7 +57,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41ac571010bd60765c56085a4f1d412012a9be2663b1a2f2b19b49318653fd0d"
 dependencies = [
- "aes 0.9.1",
+ "aes",
 ]
 
 [[package]]
@@ -85,6 +74,62 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -107,10 +152,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "base64"
@@ -192,22 +286,13 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common 0.1.7",
- "inout 0.1.4",
-]
-
-[[package]]
-name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.2.2",
- "inout 0.2.2",
+ "block-buffer",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -222,25 +307,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "cpubits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -274,16 +396,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -313,11 +425,11 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -356,7 +468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
 ]
 
@@ -398,6 +510,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +526,18 @@ dependencies = [
  "futures-sink",
  "spin 0.9.8",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -504,16 +634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,11 +661,10 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "opaque-debug",
  "polyval",
 ]
 
@@ -554,6 +673,25 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "half"
@@ -582,9 +720,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hardy-a-sabr-server"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "hardy-a-sabr",
+ "hardy-bpa",
+ "hardy-proto",
+ "serde",
+ "serde_yaml",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "hardy-async"
 version = "0.1.0"
-source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
+source = "git+https://github.com/ricktaylor/hardy.git#18516778cb7ebbe4a358c2a5b2adcf5d88b03054"
 dependencies = [
  "async-trait",
  "flume",
@@ -600,18 +753,18 @@ dependencies = [
 [[package]]
 name = "hardy-bpa"
 version = "0.1.0"
-source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
+source = "git+https://github.com/ricktaylor/hardy.git#18516778cb7ebbe4a358c2a5b2adcf5d88b03054"
 dependencies = [
  "arc-swap",
  "base64",
  "bytes",
- "foldhash",
+ "foldhash 0.2.0",
  "futures",
  "hardy-async",
  "hardy-bpv7",
  "hardy-cbor",
  "hardy-eid-patterns",
- "hashbrown",
+ "hashbrown 0.17.1",
  "lru",
  "metrics",
  "rand",
@@ -625,14 +778,14 @@ dependencies = [
 [[package]]
 name = "hardy-bpv7"
 version = "0.5.0"
-source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
+source = "git+https://github.com/ricktaylor/hardy.git#18516778cb7ebbe4a358c2a5b2adcf5d88b03054"
 dependencies = [
  "aes-gcm",
  "aes-kw",
  "base64",
  "crc",
  "hardy-cbor",
- "hashbrown",
+ "hashbrown 0.17.1",
  "hmac",
  "percent-encoding",
  "portable-atomic",
@@ -649,7 +802,7 @@ dependencies = [
 [[package]]
 name = "hardy-cbor"
 version = "1.0.0"
-source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
+source = "git+https://github.com/ricktaylor/hardy.git#18516778cb7ebbe4a358c2a5b2adcf5d88b03054"
 dependencies = [
  "half",
  "num-traits",
@@ -676,7 +829,7 @@ dependencies = [
 [[package]]
 name = "hardy-eid-patterns"
 version = "0.3.0"
-source = "git+https://github.com/ricktaylor/hardy.git#6ca0ad150e66f6ceffa8d70540c25eb2d8ae8b97"
+source = "git+https://github.com/ricktaylor/hardy.git#18516778cb7ebbe4a358c2a5b2adcf5d88b03054"
 dependencies = [
  "glob",
  "hardy-bpv7",
@@ -687,6 +840,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "hardy-proto"
+version = "0.1.0"
+source = "git+https://github.com/ricktaylor/hardy.git#18516778cb7ebbe4a358c2a5b2adcf5d88b03054"
+dependencies = [
+ "hardy-async",
+ "hardy-bpa",
+ "hardy-bpv7",
+ "hardy-eid-patterns",
+ "prost",
+ "prost-types",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-health",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,10 +877,16 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hmac"
@@ -709,6 +898,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,12 +952,68 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
+name = "hyper"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
- "generic-array",
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -734,6 +1024,12 @@ checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "hybrid-array",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -761,6 +1057,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +1083,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -804,6 +1112,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +1141,12 @@ dependencies = [
  "portable-atomic",
  "rapidhash",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -837,6 +1166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +1179,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -869,16 +1213,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
+name = "once_cell_polyfill"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -888,13 +1263,12 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "polyval"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
 dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpubits",
+ "cpufeatures",
  "universal-hash",
 ]
 
@@ -927,6 +1301,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
+ "regex",
+ "syn 2.0.118",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -1017,10 +1464,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -1072,14 +1538,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1117,6 +1605,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,6 +1637,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1169,6 +1673,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,6 +1709,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1224,10 +1756,12 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "windows-sys",
 ]
@@ -1244,6 +1778,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,6 +1802,118 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
+dependencies = [
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.118",
+ "tempfile",
+ "tonic-build",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project-lite",
+ "slab",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "trace-err"
@@ -1295,13 +1953,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -1311,19 +2011,40 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.1.7",
- "subtle",
+ "crypto-common",
+ "ctutils",
 ]
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
+name = "unsafe-libyaml"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 resolver = "3"
-members = ["cspcl", "cspcl-sys", "hardy-cspcl"]
+members = ["cspcl", "cspcl-sys", "hardy-a-sabr", "hardy-cspcl"]
 [workspace.package]
 edition = "2024"

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -3,8 +3,3 @@ resolver = "3"
 members = ["cspcl", "cspcl-sys", "hardy-cspcl"]
 [workspace.package]
 edition = "2024"
-
-[patch."https://github.com/ricktaylor/hardy.git"]
-hardy-async = { git = "https://github.com/hugoponthieu/hardy.git", branch = "cspcl-patches" }
-hardy-bpa = { git = "https://github.com/hugoponthieu/hardy.git", branch = "cspcl-patches" }
-hardy-bpv7 = { git = "https://github.com/hugoponthieu/hardy.git", branch = "cspcl-patches" }

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -10,3 +10,4 @@ hardy-bpa = { git = "https://github.com/ricktaylor/hardy.git" }
 hardy-async = { git = "https://github.com/ricktaylor/hardy.git" }
 hardy-bpv7 = { git = "https://github.com/ricktaylor/hardy.git" }
 tokio = { version = "1.52.3", features = ["macros", "rt", "time"] }
+tracing = "0.1.44"

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2024"
 hardy-bpa = { git = "https://github.com/ricktaylor/hardy.git" }
 hardy-async = { git = "https://github.com/ricktaylor/hardy.git" }
 hardy-bpv7 = { git = "https://github.com/ricktaylor/hardy.git" }
+tokio = { version = "1.52.3", features = ["macros", "rt", "time"] }

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -1,5 +1,11 @@
 [workspace]
 resolver = "3"
 members = ["cspcl", "cspcl-sys", "hardy-a-sabr", "hardy-cspcl"]
+
 [workspace.package]
 edition = "2024"
+
+[workspace.dependencies]
+hardy-bpa = { git = "https://github.com/ricktaylor/hardy.git" }
+hardy-async = { git = "https://github.com/ricktaylor/hardy.git" }
+hardy-bpv7 = { git = "https://github.com/ricktaylor/hardy.git" }

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -1,3 +1,10 @@
 [workspace]
 resolver = "3"
-members = ["cspcl", "cspcl-sys"]
+members = ["cspcl", "cspcl-sys", "hardy-cspcl"]
+[workspace.package]
+edition = "2024"
+
+[patch."https://github.com/ricktaylor/hardy.git"]
+hardy-async = { git = "https://github.com/hugoponthieu/hardy.git", branch = "cspcl-patches" }
+hardy-bpa = { git = "https://github.com/hugoponthieu/hardy.git", branch = "cspcl-patches" }
+hardy-bpv7 = { git = "https://github.com/hugoponthieu/hardy.git", branch = "cspcl-patches" }

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 resolver = "3"
-members = ["cspcl", "cspcl-sys", "hardy-a-sabr", "hardy-cspcl"]
+members = [
+    "cspcl",
+    "cspcl-sys",
+    "hardy-a-sabr",
+    "hardy-a-sabr-server",
+    "hardy-cspcl",
+]
 
 [workspace.package]
 edition = "2024"
@@ -9,5 +15,6 @@ edition = "2024"
 hardy-bpa = { git = "https://github.com/ricktaylor/hardy.git" }
 hardy-async = { git = "https://github.com/ricktaylor/hardy.git" }
 hardy-bpv7 = { git = "https://github.com/ricktaylor/hardy.git" }
-tokio = { version = "1.52.3", features = ["macros", "rt", "time"] }
+hardy-proto = { git = "https://github.com/ricktaylor/hardy.git" }
+tokio = { version = "1.52.3", features = ["macros", "rt", "signal", "time"] }
 tracing = "0.1.44"

--- a/rust-bindings/cspcl-sys/Cargo.toml
+++ b/rust-bindings/cspcl-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cspcl-sys"
 version = "0.3.0"
-edition = "2024"
+edition.workspace = true
 description = "Raw FFI bindings for the cspcl library"
 authors = ["cspcl contributors"]
 license = "MIT"

--- a/rust-bindings/cspcl/Cargo.toml
+++ b/rust-bindings/cspcl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cspcl"
 version = "0.4.0"
-edition = "2024"
+edition.workspace = true
 description = "Rust bindings for the cspcl library"
 authors = ["cspcl contributors"]
 license = "MIT"

--- a/rust-bindings/cspcl/Cargo.toml
+++ b/rust-bindings/cspcl/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["cspcl"]
 
 [dependencies]
+bytes = "1.12.0"
 cspcl-sys = { version = "0.3", path = "../cspcl-sys" }
 futures = { version = "0.3", features = ["alloc"] }
 tokio = { version = "1.52.3", features = ["macros", "rt", "time"] }

--- a/rust-bindings/cspcl/Cargo.toml
+++ b/rust-bindings/cspcl/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["cspcl"]
 bytes = "1.12.0"
 cspcl-sys = { version = "0.3", path = "../cspcl-sys" }
 futures = { version = "0.3", features = ["alloc"] }
-tokio.workspace = true
 tokio-util = "0.7"
-trace = "0.1.7"
-tracing = "0.1.44"
+tracing.workspace = true
+tokio.workspace = true

--- a/rust-bindings/cspcl/Cargo.toml
+++ b/rust-bindings/cspcl/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["cspcl"]
 bytes = "1.12.0"
 cspcl-sys = { version = "0.3", path = "../cspcl-sys" }
 futures = { version = "0.3", features = ["alloc"] }
-tokio = { version = "1.52.3", features = ["macros", "rt", "time"] }
+tokio.workspace = true
 tokio-util = "0.7"
 trace = "0.1.7"
 tracing = "0.1.44"

--- a/rust-bindings/cspcl/README.md
+++ b/rust-bindings/cspcl/README.md
@@ -14,29 +14,40 @@ Safe Rust bindings for the CubeSat Space Protocol Convergence Layer (CSPCL), ena
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-cspcl = "0.1"
+cspcl = "0.4"
+futures = "0.3"
 ```
 
 Basic usage:
 ```rust
-use cspcl::Cspcl;
+use cspcl::{CspAddress, Cspcl, Interface};
+use futures::StreamExt;
 
-// Initialize with local CSP address
-let mut cspcl = Cspcl::init(1)?;
-cspcl.open_rx_socket()?;
+// Initialize with the local CSP address and port.
+let local = CspAddress { addr: 1, port: 10 };
+let mut cspcl = Cspcl::new(local, Interface::Loopback)?;
 
-// Send bundle to CSP address 2
+// Send a bundle to a remote CSP address and port.
 let bundle = vec![/* BP7 bundle data */];
-cspcl.send_bundle(&bundle, 2)?;
+let remote = CspAddress { addr: 2, port: 10 };
+cspcl.send_bundle(&bundle, remote)?;
 
-// Receive bundle (5 second timeout)
-let (data, src_addr) = cspcl.recv_bundle(5000)?;
-println!("Received {} bytes from CSP addr {}", data.len(), src_addr);
+// Consume the instance to create an inbound bundle stream.
+let mut inbound = cspcl.inbound();
+while let Some(bundle) = inbound.next().await {
+    let bundle = bundle?;
+    println!(
+        "Received {} bytes from CSP {}:{}",
+        bundle.data.len(),
+        bundle.src_addr,
+        bundle.src_port
+    );
+}
 ```
 
 ## Documentation
 
-See [main repository README](../../README.md) for complete documentation and examples.
+See the crate-level Rust documentation for the current public API.
 
 ## License
 

--- a/rust-bindings/cspcl/README.md
+++ b/rust-bindings/cspcl/README.md
@@ -22,18 +22,19 @@ Basic usage:
 ```rust
 use cspcl::{CspAddress, Cspcl, Interface};
 use futures::StreamExt;
+use std::sync::Arc;
 
 // Initialize with the local CSP address and port.
 let local = CspAddress { addr: 1, port: 10 };
-let mut cspcl = Cspcl::new(local, Interface::Loopback)?;
+let cspcl = Arc::new(Cspcl::new(local, Interface::Loopback)?);
 
 // Send a bundle to a remote CSP address and port.
 let bundle = vec![/* BP7 bundle data */];
 let remote = CspAddress { addr: 2, port: 10 };
 cspcl.send_bundle(&bundle, remote)?;
 
-// Consume the instance to create an inbound bundle stream.
-let mut inbound = cspcl.inbound();
+// Share the instance with an inbound bundle stream.
+let mut inbound = Arc::clone(&cspcl).inbound();
 while let Some(bundle) = inbound.next().await {
     let bundle = bundle?;
     println!(

--- a/rust-bindings/cspcl/src/address.rs
+++ b/rust-bindings/cspcl/src/address.rs
@@ -1,0 +1,27 @@
+use bytes::Bytes;
+
+use crate::Error::ParseAddress;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CspAddress {
+    pub addr: u8,
+    pub port: u8,
+}
+
+impl TryFrom<Bytes> for CspAddress {
+    type Error = crate::Error;
+
+    fn try_from(value: Bytes) -> Result<Self, Self::Error> {
+        let mut raw_addr = value.into_iter();
+        raw_addr.len().eq(&2).ok_or(ParseAddress)?;
+        let addr = raw_addr.next().ok_or(ParseAddress)?;
+        let port = raw_addr.next().ok_or(ParseAddress)?;
+        Ok(Self { addr, port })
+    }
+}
+
+impl From<CspAddress> for Bytes {
+    fn from(val: CspAddress) -> Self {
+        Bytes::from(vec![val.addr, val.port])
+    }
+}

--- a/rust-bindings/cspcl/src/bundle.rs
+++ b/rust-bindings/cspcl/src/bundle.rs
@@ -44,8 +44,8 @@ impl Cspcl {
         Ok(())
     }
 
-    pub async fn inbound(self) -> InboundStream {
+    pub fn inbound(self) -> InboundStream {
         let cspcl = Arc::new(self);
-        InboundStream::new(cspcl.clone()).await
+        InboundStream::new(cspcl.clone())
     }
 }

--- a/rust-bindings/cspcl/src/bundle.rs
+++ b/rust-bindings/cspcl/src/bundle.rs
@@ -18,7 +18,7 @@ impl Cspcl {
     ///
     /// # Returns
     /// Ok(()) on success, or Err(Error) if the operation failed
-    pub fn send_bundle(&mut self, bundle: &[u8], dest: CspAddress) -> Result<()> {
+    pub fn send_bundle(&self, bundle: &[u8], dest: CspAddress) -> Result<()> {
         if bundle.is_empty() {
             return Err(Error::InvalidParam);
         }
@@ -43,8 +43,7 @@ impl Cspcl {
         Ok(())
     }
 
-    pub fn inbound(self) -> InboundStream {
-        let cspcl = Arc::new(self);
-        InboundStream::new(cspcl.clone())
+    pub fn inbound(self: Arc<Self>) -> InboundStream {
+        InboundStream::new(self)
     }
 }

--- a/rust-bindings/cspcl/src/bundle.rs
+++ b/rust-bindings/cspcl/src/bundle.rs
@@ -14,8 +14,7 @@ impl Cspcl {
     ///
     /// # Arguments
     /// * `bundle` - The serialized bundle data to send
-    /// * `dest_addr` - Destination CSP address
-    /// * `dest_port` - Destination CSP port
+    /// * `dest` - Destination CSP address and port
     ///
     /// # Returns
     /// Ok(()) on success, or Err(Error) if the operation failed

--- a/rust-bindings/cspcl/src/bundle.rs
+++ b/rust-bindings/cspcl/src/bundle.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use tracing::{debug, error};
 
-use crate::InboundStream;
 use crate::error::{Error, Result};
 use crate::instance::Cspcl;
+use crate::{CspAddress, InboundStream};
 
 impl Cspcl {
     /// Send a bundle to a remote CSP address
@@ -19,22 +19,22 @@ impl Cspcl {
     ///
     /// # Returns
     /// Ok(()) on success, or Err(Error) if the operation failed
-    pub fn send_bundle(&mut self, bundle: &[u8], dest_addr: u8, dest_port: u8) -> Result<()> {
+    pub fn send_bundle(&mut self, bundle: &[u8], dest: CspAddress) -> Result<()> {
         if bundle.is_empty() {
             return Err(Error::InvalidParam);
         }
 
         let mut inner = self.inner_mut();
-        debug!("Sending bundle to {}:{}", dest_addr, dest_port);
-        match cspcl_sys::types::send_bundle(&mut inner, bundle, dest_addr, dest_port)
+        debug!("Sending bundle to {}:{}", dest.addr, dest.port);
+        match cspcl_sys::types::send_bundle(&mut inner, bundle, dest.addr, dest.port)
             .map_err(Error::from_raw)
         {
-            Ok(_) => debug!("Bundle sent to {}:{}", dest_addr, dest_port),
+            Ok(_) => debug!("Bundle sent to {}:{}", dest.addr, dest.port),
             Err(e) => {
                 error!(
                     "Could not send bundle to {}:{} : {}",
-                    dest_addr,
-                    dest_port,
+                    dest.addr,
+                    dest.port,
                     e.to_string()
                 );
                 return Err(e);

--- a/rust-bindings/cspcl/src/error.rs
+++ b/rust-bindings/cspcl/src/error.rs
@@ -38,6 +38,8 @@ pub enum Error {
     PoolFull,
     /// Error code returned by CSPCL that this crate does not know yet
     UnknownError(cspcl_sys::cspcl_error_t),
+    /// Error returned when the address parsing fails
+    ParseAddress,
 }
 
 impl Error {
@@ -92,6 +94,7 @@ impl Error {
             Self::CspCanNotSupported => "CAN support not compiled in",
             Self::CspRouter => "CSP router task start failed",
             Self::PoolFull => "Connection pool full",
+            Self::ParseAddress => "Could not parse csp address",
             Self::UnknownError(_) => "Unknown error",
         }
     }
@@ -115,6 +118,7 @@ impl Error {
             Self::CspCanNotSupported => cspcl_sys::cspcl_error_t_CSPCL_ERR_CSP_CAN_NOT_SUPPORTED,
             Self::CspRouter => cspcl_sys::cspcl_error_t_CSPCL_ERR_CSP_ROUTER,
             Self::PoolFull => cspcl_sys::cspcl_error_t_CSPCL_ERR_POOL_FULL,
+            Self::ParseAddress => 420,
             Self::UnknownError(code) => *code,
         }
     }

--- a/rust-bindings/cspcl/src/inbound.rs
+++ b/rust-bindings/cspcl/src/inbound.rs
@@ -44,7 +44,7 @@ impl Stream for InboundStream {
 }
 
 impl InboundStream {
-    pub async fn new(cspcl: Arc<Cspcl>) -> Self {
+    pub fn new(cspcl: Arc<Cspcl>) -> Self {
         let (tx, rx) = mpsc::unbounded();
         debug!("Creating inbound stream");
 

--- a/rust-bindings/cspcl/src/instance.rs
+++ b/rust-bindings/cspcl/src/instance.rs
@@ -9,7 +9,17 @@ use crate::{
 };
 
 /// Safe wrapper for CSPCL instance
-#[derive(Clone)]
+///
+/// `Cspcl` owns the underlying C resource and must not be cloned into another
+/// Rust owner that would also run cleanup on drop.
+///
+/// ```compile_fail
+/// use cspcl::Cspcl;
+///
+/// fn duplicate_cleanup_owner(cspcl: Cspcl) {
+///     let _clone = cspcl.clone();
+/// }
+/// ```
 pub struct Cspcl {
     inner: Arc<RwLock<cspcl_sys::cspcl_t>>,
     inbound_shutdown: CancellationToken,
@@ -33,7 +43,7 @@ impl Cspcl {
     }
 
     /// Close the receive socket
-    pub fn close_rx_socket(self) {
+    pub fn close_rx_socket(&self) {
         self.inbound_shutdown.cancel();
         let mut cspcl = self.inner_mut();
         cspcl_sys::types::close_rx_socket(&mut cspcl);

--- a/rust-bindings/cspcl/src/instance.rs
+++ b/rust-bindings/cspcl/src/instance.rs
@@ -3,7 +3,10 @@ use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use cspcl_sys::types::AcceptedConn;
 use tokio_util::sync::CancellationToken;
 
-use crate::error::{Error, Result, from_sys_result};
+use crate::{
+    CspAddress,
+    error::{Error, Result, from_sys_result},
+};
 
 /// Safe wrapper for CSPCL instance
 #[derive(Clone)]
@@ -14,10 +17,10 @@ pub struct Cspcl {
 
 impl Cspcl {
     /// Initialize a new CSPCL instance with local CSP address
-    pub fn new(local_addr: u8, local_port: u8, interface: super::Interface) -> Result<Self> {
+    pub fn new(local: CspAddress, interface: super::Interface) -> Result<Self> {
         let config = cspcl_sys::types::CspclConfig {
-            local_addr,
-            csp_port: local_port,
+            local_addr: local.addr,
+            csp_port: local.port,
             interface,
         };
 
@@ -44,11 +47,6 @@ impl Cspcl {
             accepted_conn,
         ))?;
         Ok(accepted_conn)
-    }
-
-    /// Get local CSP address
-    pub fn local_addr(&self) -> u8 {
-        self.inner().local_addr
     }
 
     /// Check if initialized

--- a/rust-bindings/cspcl/src/lib.rs
+++ b/rust-bindings/cspcl/src/lib.rs
@@ -4,12 +4,14 @@
 //! enabling transmission of BP7 bundles over CSP UDP.
 
 // Module declarations
+mod address;
 mod bundle;
 mod error;
 mod inbound;
 mod instance;
 
 // Public exports
+pub use address::CspAddress;
 pub use cspcl_sys::types::InterfaceConfig as Interface;
 pub use error::{Error, Result};
 pub use inbound::InboundStream;

--- a/rust-bindings/cspcl/src/lib.rs
+++ b/rust-bindings/cspcl/src/lib.rs
@@ -1,7 +1,7 @@
 //! Safe Rust bindings for CSPCL (CubeSat Space Protocol Convergence Layer)
 //!
 //! This crate provides high-level safe wrappers around the C CSPCL library,
-//! enabling transmission of BP7 bundles over CSP UDP.
+//! enabling transmission of BP7 bundles over CSP.
 
 // Module declarations
 mod address;
@@ -17,8 +17,12 @@ pub use error::{Error, Result};
 pub use inbound::InboundStream;
 pub use instance::Cspcl;
 
+/// Bundle received from an inbound CSP connection.
 pub struct Bundle {
+    /// Serialized bundle payload.
     pub data: Vec<u8>,
+    /// Source CSP node address.
     pub src_addr: u8,
+    /// Source CSP port.
     pub src_port: u8,
 }

--- a/rust-bindings/hardy-a-sabr-server/Cargo.toml
+++ b/rust-bindings/hardy-a-sabr-server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "hardy-a-sabr-server"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+hardy-a-sabr = { path = "../hardy-a-sabr", features = ["serde"] }
+hardy-bpa.workspace = true
+hardy-proto.workspace = true
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/rust-bindings/hardy-a-sabr-server/examples/a-sabr-router.yaml
+++ b/rust-bindings/hardy-a-sabr-server/examples/a-sabr-router.yaml
@@ -3,12 +3,10 @@ agent_name: "a-sabr"
 
 runtime:
   source: 0
-  start_time: 0.0
+  start_time: 0
   safety_tick_secs: 10
 
   engine:
-    check_size: false
-    check_priority: false
     max_entries: 10
 
   topology:
@@ -20,16 +18,16 @@ runtime:
     contacts:
       - tx_node_id: 0
         rx_node_id: 1
-        start: 0.0
-        end: 60.0
-        rate: 1000000.0
-        delay: 1.0
+        start: 0
+        end: 60000
+        rate: 1000000
+        delay: 1000
 
   projection:
     bundle:
-      size: 1.0
+      size: 1
       priority: 0
-      expiration_horizon: 3600.0
+      expiration_horizon: 3600000
     destinations:
       - pattern: "ipn:1.2.*"
         asabr_destination: 1

--- a/rust-bindings/hardy-a-sabr-server/examples/a-sabr-router.yaml
+++ b/rust-bindings/hardy-a-sabr-server/examples/a-sabr-router.yaml
@@ -1,0 +1,36 @@
+grpc_addr: "http://[::1]:51051"
+agent_name: "a-sabr"
+
+runtime:
+  source: 0
+  start_time: 0.0
+  safety_tick_secs: 10
+
+  engine:
+    check_size: false
+    check_priority: false
+    max_entries: 10
+
+  topology:
+    nodes:
+      - asabr_node_id: 0
+        hardy_node_id: "ipn:0.1.0"
+      - asabr_node_id: 1
+        hardy_node_id: "ipn:1.2.0"
+    contacts:
+      - tx_node_id: 0
+        rx_node_id: 1
+        start: 0.0
+        end: 60.0
+        rate: 1000000.0
+        delay: 1.0
+
+  projection:
+    bundle:
+      size: 1.0
+      priority: 0
+      expiration_horizon: 3600.0
+    destinations:
+      - pattern: "ipn:1.2.*"
+        asabr_destination: 1
+        route_priority: 100

--- a/rust-bindings/hardy-a-sabr-server/src/main.rs
+++ b/rust-bindings/hardy-a-sabr-server/src/main.rs
@@ -1,0 +1,68 @@
+use std::{path::PathBuf, sync::Arc};
+
+use clap::Parser;
+use hardy_a_sabr::config::RuntimeConfig;
+use hardy_bpa::bpa::BpaRegistration;
+use hardy_proto::client::RemoteBpa;
+use serde::Deserialize;
+use tracing::info;
+
+#[derive(Debug, Parser)]
+#[command(name = "hardy-a-sabr-server")]
+#[command(about = "Run a remote Hardy A-SABR routing agent over gRPC")]
+struct Cli {
+    #[arg(short, long, value_name = "PATH")]
+    config: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+struct Config {
+    grpc_addr: String,
+    #[serde(default = "default_agent_name")]
+    agent_name: String,
+    runtime: RuntimeConfig,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            std::env::var("RUST_LOG")
+                .unwrap_or_else(|_| "info,hardy_a_sabr=debug,hardy_a_sabr_server=debug".into()),
+        )
+        .init();
+
+    let cli = Cli::parse();
+    let config = load_config(&cli.config)?;
+
+    let agent_name = config.agent_name;
+    let grpc_addr = config.grpc_addr;
+    let router = Arc::new(config.runtime.into_router());
+    let remote_bpa = RemoteBpa::new(grpc_addr.clone());
+
+    let node_ids = remote_bpa
+        .register_routing_agent(agent_name.clone(), router.clone())
+        .await?;
+
+    info!(
+        agent = %agent_name,
+        grpc_addr = %grpc_addr,
+        node_ids = ?node_ids,
+        "A-SABR routing agent registered with remote BPA"
+    );
+
+    tokio::signal::ctrl_c().await?;
+
+    info!(agent = %agent_name, "A-SABR routing agent shutting down");
+
+    Ok(())
+}
+
+fn load_config(path: &PathBuf) -> Result<Config, Box<dyn std::error::Error + Send + Sync>> {
+    let contents = std::fs::read_to_string(path)?;
+    Ok(serde_yaml::from_str(&contents)?)
+}
+
+fn default_agent_name() -> String {
+    "a-sabr".into()
+}

--- a/rust-bindings/hardy-a-sabr/Cargo.toml
+++ b/rust-bindings/hardy-a-sabr/Cargo.toml
@@ -9,3 +9,4 @@ hardy-eid-patterns = { git = "https://github.com/ricktaylor/hardy.git" }
 hardy-bpa.workspace = true
 hardy-async.workspace = true
 hardy-bpv7.workspace = true
+tokio.workspace = true

--- a/rust-bindings/hardy-a-sabr/Cargo.toml
+++ b/rust-bindings/hardy-a-sabr/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
+hardy-eid-patterns = { git = "https://github.com/ricktaylor/hardy.git" }
 hardy-bpa.workspace = true
 hardy-async.workspace = true
 hardy-bpv7.workspace = true

--- a/rust-bindings/hardy-a-sabr/Cargo.toml
+++ b/rust-bindings/hardy-a-sabr/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
+a_sabr = { git = "https://github.com/DTN-MTP/A-SABR.git" }
 hardy-eid-patterns = { git = "https://github.com/ricktaylor/hardy.git" }
 hardy-bpa.workspace = true
 hardy-async.workspace = true

--- a/rust-bindings/hardy-a-sabr/Cargo.toml
+++ b/rust-bindings/hardy-a-sabr/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "hardy-a-sabr"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]

--- a/rust-bindings/hardy-a-sabr/Cargo.toml
+++ b/rust-bindings/hardy-a-sabr/Cargo.toml
@@ -9,7 +9,7 @@ serde = ["dep:serde", "hardy-bpv7/serde", "hardy-eid-patterns/serde"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }
-a_sabr = { git = "https://github.com/DTN-MTP/A-SABR.git" }
+a_sabr = { git = "https://github.com/DTN-MTP/A-SABR.git", rev = "16ffed523bf862ba770bf1b07adc8ee533066f1a" }
 hardy-eid-patterns = { git = "https://github.com/ricktaylor/hardy.git" }
 hardy-bpa.workspace = true
 hardy-async.workspace = true

--- a/rust-bindings/hardy-a-sabr/Cargo.toml
+++ b/rust-bindings/hardy-a-sabr/Cargo.toml
@@ -10,3 +10,4 @@ hardy-bpa.workspace = true
 hardy-async.workspace = true
 hardy-bpv7.workspace = true
 tokio.workspace = true
+tracing.workspace = true

--- a/rust-bindings/hardy-a-sabr/Cargo.toml
+++ b/rust-bindings/hardy-a-sabr/Cargo.toml
@@ -3,7 +3,12 @@ name = "hardy-a-sabr"
 version = "0.1.0"
 edition.workspace = true
 
+[features]
+default = []
+serde = ["dep:serde", "hardy-bpv7/serde", "hardy-eid-patterns/serde"]
+
 [dependencies]
+serde = { version = "1", features = ["derive"], optional = true }
 a_sabr = { git = "https://github.com/DTN-MTP/A-SABR.git" }
 hardy-eid-patterns = { git = "https://github.com/ricktaylor/hardy.git" }
 hardy-bpa.workspace = true

--- a/rust-bindings/hardy-a-sabr/Cargo.toml
+++ b/rust-bindings/hardy-a-sabr/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
+hardy-bpa.workspace = true
+hardy-async.workspace = true
+hardy-bpv7.workspace = true

--- a/rust-bindings/hardy-a-sabr/src/agent.rs
+++ b/rust-bindings/hardy-a-sabr/src/agent.rs
@@ -6,7 +6,11 @@ use hardy_bpa::{
 };
 use hardy_bpv7::eid::NodeId;
 
-use crate::{refresh::refresh_routes, router::Router};
+use crate::{
+    refresh::refresh_routes,
+    router::Router,
+    routes::{apply_route_diff, diff_routes},
+};
 
 #[async_trait]
 impl RoutingAgent for Router {
@@ -42,6 +46,23 @@ impl RoutingAgent for Router {
     }
 
     async fn on_unregister(&self) {
+        let sink = self.sink.lock().unwrap().clone();
+        let installed = self.installed.lock().unwrap().clone();
+
+        if let Some(sink) = sink {
+            let diff = diff_routes(&installed, &[]);
+
+            if let Err(error) = apply_route_diff(&*sink, &diff).await {
+                eprintln!(
+                    "A-SABR route withdrawal failed:
+              {error:?}"
+                );
+            }
+        }
+
+        let mut stored_installed = self.installed.lock().unwrap();
+        stored_installed.clear();
+
         let mut stored_sink = self.sink.lock().unwrap();
         *stored_sink = None;
     }

--- a/rust-bindings/hardy-a-sabr/src/agent.rs
+++ b/rust-bindings/hardy-a-sabr/src/agent.rs
@@ -21,6 +21,7 @@ impl RoutingAgent for Router {
             topology,
             self.engine_config.clone(),
             self.projection_config.clone(),
+            self.start_time,
         );
 
         scheduler.start();

--- a/rust-bindings/hardy-a-sabr/src/agent.rs
+++ b/rust-bindings/hardy-a-sabr/src/agent.rs
@@ -1,14 +1,48 @@
+use std::sync::Arc;
+
 use hardy_bpa::{
     async_trait,
     routing::{RoutingAgent, RoutingSink},
 };
 use hardy_bpv7::eid::NodeId;
 
-use crate::router::Router;
+use crate::{refresh::refresh_routes, router::Router};
 
 #[async_trait]
 impl RoutingAgent for Router {
-    async fn on_register(&self, sink: Box<dyn RoutingSink>, node_ids: &[NodeId]) {}
+    async fn on_register(&self, sink: Box<dyn RoutingSink>, _node_ids: &[NodeId]) {
+        let sink: Arc<dyn RoutingSink> = sink.into();
+        {
+            let mut stored_sink = self.sink.lock().unwrap();
+            *stored_sink = Some(sink.clone());
+        }
 
-    async fn on_unregister(&self) {}
+        let topology = self.topology.lock().unwrap().clone();
+        let mut installed = self.installed.lock().unwrap().clone();
+
+        if let Err(error) = refresh_routes(
+            &*sink,
+            &mut installed,
+            &topology,
+            &self.engine_config,
+            &self.projection_config,
+            self.source,
+            0.0,
+        )
+        .await
+        {
+            eprintln!(
+                "A-SABR initial route refresh failed:
+              {error:?}"
+            );
+            return;
+        }
+        let mut stored_installed = self.installed.lock().unwrap();
+        *stored_installed = installed;
+    }
+
+    async fn on_unregister(&self) {
+        let mut stored_sink = self.sink.lock().unwrap();
+        *stored_sink = None;
+    }
 }

--- a/rust-bindings/hardy-a-sabr/src/agent.rs
+++ b/rust-bindings/hardy-a-sabr/src/agent.rs
@@ -7,7 +7,6 @@ use hardy_bpa::{
 use hardy_bpv7::eid::NodeId;
 
 use crate::{
-    refresh::refresh_routes,
     router::Router,
     routes::{apply_route_diff, diff_routes},
 };
@@ -16,33 +15,19 @@ use crate::{
 impl RoutingAgent for Router {
     async fn on_register(&self, sink: Box<dyn RoutingSink>, _node_ids: &[NodeId]) {
         let sink: Arc<dyn RoutingSink> = sink.into();
+
         {
             let mut stored_sink = self.sink.lock().unwrap();
             *stored_sink = Some(sink.clone());
         }
 
-        let topology = self.topology.lock().unwrap().clone();
-        let mut installed = self.installed.lock().unwrap().clone();
-
-        if let Err(error) = refresh_routes(
-            &*sink,
-            &mut installed,
-            &topology,
-            &self.engine_config,
-            &self.projection_config,
-            self.source,
-            0.0,
-        )
-        .await
-        {
+        if let Err(error) = self.refresh_with_sink(&*sink, 0.0).await {
             eprintln!(
                 "A-SABR initial route refresh failed:
-              {error:?}"
+          {error:?}"
             );
             return;
         }
-        let mut stored_installed = self.installed.lock().unwrap();
-        *stored_installed = installed;
     }
 
     async fn on_unregister(&self) {

--- a/rust-bindings/hardy-a-sabr/src/agent.rs
+++ b/rust-bindings/hardy-a-sabr/src/agent.rs
@@ -22,6 +22,7 @@ impl RoutingAgent for Router {
             self.engine_config.clone(),
             self.projection_config.clone(),
             self.start_time,
+            self.safety_tick,
         );
 
         scheduler.start();

--- a/rust-bindings/hardy-a-sabr/src/agent.rs
+++ b/rust-bindings/hardy-a-sabr/src/agent.rs
@@ -1,0 +1,14 @@
+use hardy_bpa::{
+    async_trait,
+    routing::{RoutingAgent, RoutingSink},
+};
+use hardy_bpv7::eid::NodeId;
+
+use crate::router::Router;
+
+#[async_trait]
+impl RoutingAgent for Router {
+    async fn on_register(&self, sink: Box<dyn RoutingSink>, node_ids: &[NodeId]) {}
+
+    async fn on_unregister(&self) {}
+}

--- a/rust-bindings/hardy-a-sabr/src/agent.rs
+++ b/rust-bindings/hardy-a-sabr/src/agent.rs
@@ -11,6 +11,15 @@ use crate::{router::Router, scheduler::Scheduler};
 #[async_trait]
 impl RoutingAgent for Router {
     async fn on_register(&self, sink: Box<dyn RoutingSink>, _node_ids: &[NodeId]) {
+        let previous_scheduler = {
+            let mut stored_scheduler = self.scheduler.lock().unwrap();
+            stored_scheduler.take()
+        };
+
+        if let Some(previous_scheduler) = previous_scheduler {
+            previous_scheduler.shutdown().await;
+        }
+
         let sink: Arc<dyn RoutingSink> = sink.into();
 
         let topology = self.topology.lock().unwrap().clone();

--- a/rust-bindings/hardy-a-sabr/src/agent.rs
+++ b/rust-bindings/hardy-a-sabr/src/agent.rs
@@ -6,49 +6,40 @@ use hardy_bpa::{
 };
 use hardy_bpv7::eid::NodeId;
 
-use crate::{
-    router::Router,
-    routes::{apply_route_diff, diff_routes},
-};
+use crate::{router::Router, scheduler::Scheduler};
 
 #[async_trait]
 impl RoutingAgent for Router {
     async fn on_register(&self, sink: Box<dyn RoutingSink>, _node_ids: &[NodeId]) {
         let sink: Arc<dyn RoutingSink> = sink.into();
 
+        let topology = self.topology.lock().unwrap().clone();
+
+        let (scheduler, handle) = Scheduler::new(
+            sink.clone(),
+            self.source,
+            topology,
+            self.engine_config.clone(),
+            self.projection_config.clone(),
+        );
+
+        scheduler.start();
+
         {
-            let mut stored_sink = self.sink.lock().unwrap();
-            *stored_sink = Some(sink.clone());
+            let mut stored_scheduler = self.scheduler.lock().unwrap();
+            *stored_scheduler = Some(handle.clone());
         }
 
-        if let Err(error) = self.refresh_with_sink(&*sink, 0.0).await {
-            eprintln!(
-                "A-SABR initial route refresh failed:
-          {error:?}"
-            );
-            return;
-        }
+        handle.refresh().await
     }
 
     async fn on_unregister(&self) {
-        let sink = self.sink.lock().unwrap().clone();
-        let installed = self.installed.lock().unwrap().clone();
-
-        if let Some(sink) = sink {
-            let diff = diff_routes(&installed, &[]);
-
-            if let Err(error) = apply_route_diff(&*sink, &diff).await {
-                eprintln!(
-                    "A-SABR route withdrawal failed:
-              {error:?}"
-                );
-            }
+        let scheduler = {
+            let mut stored_scheduler = self.scheduler.lock().unwrap();
+            stored_scheduler.take()
+        };
+        if let Some(scheduler) = scheduler {
+            scheduler.shutdown().await;
         }
-
-        let mut stored_installed = self.installed.lock().unwrap();
-        stored_installed.clear();
-
-        let mut stored_sink = self.sink.lock().unwrap();
-        *stored_sink = None;
     }
 }

--- a/rust-bindings/hardy-a-sabr/src/config.rs
+++ b/rust-bindings/hardy-a-sabr/src/config.rs
@@ -1,0 +1,37 @@
+use std::time::Duration;
+
+use crate::{
+    Router, engine::ShadowEngineConfig, projection::ProjectionConfig, topology::TopologySnapshot,
+};
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RuntimeConfig {
+    pub source: u16,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub start_time: f64,
+    #[cfg_attr(feature = "serde", serde(default = "default_safety_tick_secs"))]
+    pub safety_tick_secs: u64,
+    pub topology: TopologySnapshot,
+    pub projection: ProjectionConfig,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub engine: ShadowEngineConfig,
+}
+
+impl RuntimeConfig {
+    pub fn safety_tick(&self) -> Duration {
+        Duration::from_secs(self.safety_tick_secs)
+    }
+    pub fn into_router(self) -> Router {
+        let safety_tick = self.safety_tick();
+        Router::new(self.source, self.topology, self.projection)
+            .with_start_time(self.start_time)
+            .with_safety_tick(safety_tick)
+            .with_engine_config(self.engine)
+    }
+}
+
+#[cfg(feature = "serde")]
+fn default_safety_tick_secs() -> u64 {
+    60
+}

--- a/rust-bindings/hardy-a-sabr/src/config.rs
+++ b/rust-bindings/hardy-a-sabr/src/config.rs
@@ -9,7 +9,7 @@ use crate::{
 pub struct RuntimeConfig {
     pub source: u16,
     #[cfg_attr(feature = "serde", serde(default))]
-    pub start_time: f64,
+    pub start_time: i64,
     #[cfg_attr(feature = "serde", serde(default = "default_safety_tick_secs"))]
     pub safety_tick_secs: u64,
     pub topology: TopologySnapshot,

--- a/rust-bindings/hardy-a-sabr/src/engine.rs
+++ b/rust-bindings/hardy-a-sabr/src/engine.rs
@@ -1,81 +1,60 @@
-use std::{cell::RefCell, rc::Rc};
-
 use a_sabr::{
     bundle::Bundle,
     contact::{Contact, ContactInfo},
     contact_manager::legacy::evl::EVLManager,
-    contact_plan::ContactPlan,
+    contact_plan::{ContactPlan, RealNode},
     errors::ASABRError,
+    multigraph::RoutableNodeRef,
     node::{Node, NodeInfo},
     node_manager::none::NoManagement,
-    route_storage::cache::TreeCache,
-    routing::{Router, aliases::SpsnHybridParenting},
-    vertex::Vertex,
+    pathfinding::top_level::aliases::SpsnHybridParenting,
+    utils::{Router, make_guard},
 };
 
 use crate::{projection::RepresentativeBundle, topology::TopologySnapshot};
 
-pub type ShadowRouter = SpsnHybridParenting<NoManagement, EVLManager>;
-
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ShadowEngineConfig {
-    pub check_size: bool,
-    pub check_priority: bool,
     pub max_entries: usize,
 }
 
 impl Default for ShadowEngineConfig {
     fn default() -> Self {
-        Self {
-            check_size: false,
-            check_priority: false,
-            max_entries: 10,
-        }
+        Self { max_entries: 10 }
     }
-}
-
-pub fn new_route_cache(
-    config: &ShadowEngineConfig,
-) -> Rc<RefCell<TreeCache<NoManagement, EVLManager>>> {
-    Rc::new(RefCell::new(TreeCache::new(
-        config.check_size,
-        config.check_priority,
-        config.max_entries,
-    )))
 }
 
 pub fn build_contact_plan(
     topology: &TopologySnapshot,
 ) -> Result<ContactPlan<NoManagement, EVLManager>, ASABRError> {
-    let mut vertices = topology
+    let mut nodes = topology
         .nodes
         .iter()
         .filter_map(|node| {
             Node::try_new(
                 NodeInfo {
-                    id: node.asabr_node_id,
+                    id: (node.asabr_node_id as usize).into(),
                     name: node.hardy_node_id.to_string().into(),
                     excluded: false,
                 },
                 NoManagement {},
             )
-            .map(Vertex::INode)
+            .map(|inode| (node.asabr_node_id, RealNode::Inode(inode)))
         })
         .collect::<Vec<_>>();
 
-    vertices.sort_by(|left, right| {
-        let left_id = match left {
-            Vertex::INode(node) | Vertex::ENode(node) => node.info.id,
-            Vertex::VNode((_, node_id)) => *node_id,
-        };
-        let right_id = match right {
-            Vertex::INode(node) | Vertex::ENode(node) => node.info.id,
-            Vertex::VNode((_, node_id)) => *node_id,
-        };
+    nodes.sort_by_key(|(id, _)| *id);
 
-        left_id.cmp(&right_id)
-    });
+    debug_assert!(
+        nodes
+            .iter()
+            .enumerate()
+            .all(|(index, (id, _))| index as u16 == *id),
+        "asabr_node_id values must be contiguous starting at 0"
+    );
+
+    let realnodes = nodes.into_iter().map(|(_, node)| node).collect::<Vec<_>>();
 
     let contacts = topology
         .contacts
@@ -83,8 +62,8 @@ pub fn build_contact_plan(
         .filter_map(|contact| {
             Contact::try_new(
                 ContactInfo::new(
-                    contact.tx_node_id,
-                    contact.rx_node_id,
+                    (contact.tx_node_id as usize).into(),
+                    (contact.rx_node_id as usize).into(),
                     contact.start,
                     contact.end,
                 ),
@@ -93,17 +72,7 @@ pub fn build_contact_plan(
         })
         .collect::<Vec<_>>();
 
-    Ok(ContactPlan::new(vertices, contacts, None))
-}
-
-pub fn build_shadow_router(
-    topology: &TopologySnapshot,
-    config: &ShadowEngineConfig,
-) -> Result<ShadowRouter, ASABRError> {
-    let contact_plan = build_contact_plan(topology)?;
-    let route_cache = new_route_cache(config);
-
-    ShadowRouter::new(contact_plan, route_cache, config.check_priority)
+    Ok(ContactPlan::new(realnodes, Vec::new(), contacts))
 }
 
 pub fn compute_first_hop(
@@ -111,26 +80,94 @@ pub fn compute_first_hop(
     config: &ShadowEngineConfig,
     source: u16,
     destination: u16,
-    now: f64,
+    now: i64,
     representative: &RepresentativeBundle,
 ) -> Result<Option<u16>, ASABRError> {
-    let mut router = build_shadow_router(topology, config)?;
+    let contact_plan = build_contact_plan(topology)?;
+
+    make_guard!(id);
+    let mut router = Router::<_, _, SpsnHybridParenting<1, _, _, _>, RoutableNodeRef>::build(
+        id,
+        contact_plan,
+        (config.max_entries, ()),
+    )?;
 
     let bundle = Bundle {
-        source,
-        destinations: vec![destination],
         priority: representative.priority,
         size: representative.size,
         expiration: now + representative.expiration_horizon,
     };
 
-    let excluded_nodes = Vec::new();
+    let Some(source_ref) = router.node_id_ref((source as usize).into())?.internal() else {
+        return Ok(None);
+    };
+    let destination_ref = router
+        .node_id_ref((destination as usize).into())?
+        .routable()?;
 
-    Ok(router
-        .route(source, &bundle, now, &excluded_nodes)?
-        .and_then(|output| {
-            output
-                .lazy_get_for_unicast(destination)
-                .map(|(contact, _route)| contact.borrow().info.rx_node_id)
-        }))
+    let output = router.route(destination_ref, now, source_ref, &bundle, None)?;
+
+    Ok(output.map(|(_path, first_hop)| {
+        usize::from(
+            first_hop
+                .rx_node
+                .internal()
+                .expect("A-SABR first-hop rx_node is always an internal node"),
+        ) as u16
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::topology::{ContactWindow, NodeMapping, TopologySnapshot};
+    use hardy_bpv7::eid::NodeId;
+
+    fn node(asabr_node_id: u16, eid: &str) -> NodeMapping {
+        NodeMapping {
+            asabr_node_id,
+            hardy_node_id: eid.parse::<NodeId>().expect("valid node id"),
+        }
+    }
+
+    fn contact(tx: u16, rx: u16, start: i64, end: i64) -> ContactWindow {
+        ContactWindow {
+            tx_node_id: tx,
+            rx_node_id: rx,
+            start,
+            end,
+            rate: 1_000_000,
+            delay: 1,
+        }
+    }
+
+    #[test]
+    fn first_hop_follows_linear_plan() {
+        // 0 -> 1 -> 2, all contacts open for the whole horizon.
+        let topology = TopologySnapshot {
+            nodes: vec![node(0, "ipn:1.0"), node(1, "ipn:2.0"), node(2, "ipn:3.0")],
+            contacts: vec![contact(0, 1, 0, 100_000), contact(1, 2, 0, 100_000)],
+        };
+        let config = ShadowEngineConfig::default();
+        let representative = RepresentativeBundle::default();
+
+        let hop = compute_first_hop(&topology, &config, 0, 2, 0, &representative)
+            .expect("routing succeeds");
+        assert_eq!(hop, Some(1));
+    }
+
+    #[test]
+    fn no_path_returns_none() {
+        // 0 -> 1 only; node 2 is unreachable.
+        let topology = TopologySnapshot {
+            nodes: vec![node(0, "ipn:1.0"), node(1, "ipn:2.0"), node(2, "ipn:3.0")],
+            contacts: vec![contact(0, 1, 0, 100_000)],
+        };
+        let config = ShadowEngineConfig::default();
+        let representative = RepresentativeBundle::default();
+
+        let hop = compute_first_hop(&topology, &config, 0, 2, 0, &representative)
+            .expect("routing succeeds");
+        assert_eq!(hop, None);
+    }
 }

--- a/rust-bindings/hardy-a-sabr/src/engine.rs
+++ b/rust-bindings/hardy-a-sabr/src/engine.rs
@@ -18,6 +18,7 @@ use crate::{projection::RepresentativeBundle, topology::TopologySnapshot};
 pub type ShadowRouter = SpsnHybridParenting<NoManagement, EVLManager>;
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ShadowEngineConfig {
     pub check_size: bool,
     pub check_priority: bool,

--- a/rust-bindings/hardy-a-sabr/src/engine.rs
+++ b/rust-bindings/hardy-a-sabr/src/engine.rs
@@ -1,6 +1,7 @@
 use std::{cell::RefCell, rc::Rc};
 
 use a_sabr::{
+    bundle::Bundle,
     contact::{Contact, ContactInfo},
     contact_manager::legacy::evl::EVLManager,
     contact_plan::ContactPlan,
@@ -8,11 +9,11 @@ use a_sabr::{
     node::{Node, NodeInfo},
     node_manager::none::NoManagement,
     route_storage::cache::TreeCache,
-    routing::aliases::SpsnHybridParenting,
+    routing::{Router, aliases::SpsnHybridParenting},
     vertex::Vertex,
 };
 
-use crate::topology::TopologySnapshot;
+use crate::{projection::RepresentativeBundle, topology::TopologySnapshot};
 
 pub type ShadowRouter = SpsnHybridParenting<NoManagement, EVLManager>;
 
@@ -102,4 +103,33 @@ pub fn build_shadow_router(
     let route_cache = new_route_cache(config);
 
     ShadowRouter::new(contact_plan, route_cache, config.check_priority)
+}
+
+pub fn compute_first_hop(
+    topology: &TopologySnapshot,
+    config: &ShadowEngineConfig,
+    source: u16,
+    destination: u16,
+    now: f64,
+    representative: &RepresentativeBundle,
+) -> Result<Option<u16>, ASABRError> {
+    let mut router = build_shadow_router(topology, config)?;
+
+    let bundle = Bundle {
+        source,
+        destinations: vec![destination],
+        priority: representative.priority,
+        size: representative.size,
+        expiration: now + representative.expiration_horizon,
+    };
+
+    let excluded_nodes = Vec::new();
+
+    Ok(router
+        .route(source, &bundle, now, &excluded_nodes)?
+        .and_then(|output| {
+            output
+                .lazy_get_for_unicast(destination)
+                .map(|(contact, _route)| contact.borrow().info.rx_node_id)
+        }))
 }

--- a/rust-bindings/hardy-a-sabr/src/engine.rs
+++ b/rust-bindings/hardy-a-sabr/src/engine.rs
@@ -1,0 +1,35 @@
+use std::{cell::RefCell, rc::Rc};
+
+use a_sabr::{
+    contact_manager::legacy::evl::EVLManager, node_manager::none::NoManagement,
+    route_storage::cache::TreeCache, routing::aliases::SpsnHybridParenting,
+};
+
+pub type ShadowRouter = SpsnHybridParenting<NoManagement, EVLManager>;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ShadowEngineConfig {
+    pub check_size: bool,
+    pub check_priority: bool,
+    pub max_entries: usize,
+}
+
+impl Default for ShadowEngineConfig {
+    fn default() -> Self {
+        Self {
+            check_size: false,
+            check_priority: false,
+            max_entries: 10,
+        }
+    }
+}
+
+pub fn new_route_cache(
+    config: &ShadowEngineConfig,
+) -> Rc<RefCell<TreeCache<NoManagement, EVLManager>>> {
+    Rc::new(RefCell::new(TreeCache::new(
+        config.check_size,
+        config.check_priority,
+        config.max_entries,
+    )))
+}

--- a/rust-bindings/hardy-a-sabr/src/engine.rs
+++ b/rust-bindings/hardy-a-sabr/src/engine.rs
@@ -46,13 +46,15 @@ pub fn build_contact_plan(
 
     nodes.sort_by_key(|(id, _)| *id);
 
-    debug_assert!(
-        nodes
-            .iter()
-            .enumerate()
-            .all(|(index, (id, _))| index as u16 == *id),
-        "asabr_node_id values must be contiguous starting at 0"
-    );
+    if !nodes
+        .iter()
+        .enumerate()
+        .all(|(index, (id, _))| index as u16 == *id)
+    {
+        return Err(ASABRError::ContactPlanError(
+            "asabr_node_id values must be contiguous starting at 0",
+        ));
+    }
 
     let realnodes = nodes.into_iter().map(|(_, node)| node).collect::<Vec<_>>();
 
@@ -154,6 +156,16 @@ mod tests {
         let hop = compute_first_hop(&topology, &config, 0, 2, 0, &representative)
             .expect("routing succeeds");
         assert_eq!(hop, Some(1));
+    }
+
+    #[test]
+    fn non_contiguous_node_ids_error() {
+        // Gap at id 2: sorted realnodes would misalign index != asabr_node_id.
+        let topology = TopologySnapshot {
+            nodes: vec![node(0, "ipn:1.0"), node(1, "ipn:2.0"), node(3, "ipn:4.0")],
+            contacts: vec![],
+        };
+        assert!(build_contact_plan(&topology).is_err());
     }
 
     #[test]

--- a/rust-bindings/hardy-a-sabr/src/engine.rs
+++ b/rust-bindings/hardy-a-sabr/src/engine.rs
@@ -1,9 +1,18 @@
 use std::{cell::RefCell, rc::Rc};
 
 use a_sabr::{
-    contact_manager::legacy::evl::EVLManager, node_manager::none::NoManagement,
-    route_storage::cache::TreeCache, routing::aliases::SpsnHybridParenting,
+    contact::{Contact, ContactInfo},
+    contact_manager::legacy::evl::EVLManager,
+    contact_plan::ContactPlan,
+    errors::ASABRError,
+    node::{Node, NodeInfo},
+    node_manager::none::NoManagement,
+    route_storage::cache::TreeCache,
+    routing::aliases::SpsnHybridParenting,
+    vertex::Vertex,
 };
+
+use crate::topology::TopologySnapshot;
 
 pub type ShadowRouter = SpsnHybridParenting<NoManagement, EVLManager>;
 
@@ -32,4 +41,65 @@ pub fn new_route_cache(
         config.check_priority,
         config.max_entries,
     )))
+}
+
+pub fn build_contact_plan(
+    topology: &TopologySnapshot,
+) -> Result<ContactPlan<NoManagement, EVLManager>, ASABRError> {
+    let mut vertices = topology
+        .nodes
+        .iter()
+        .filter_map(|node| {
+            Node::try_new(
+                NodeInfo {
+                    id: node.asabr_node_id,
+                    name: node.hardy_node_id.to_string().into(),
+                    excluded: false,
+                },
+                NoManagement {},
+            )
+            .map(Vertex::INode)
+        })
+        .collect::<Vec<_>>();
+
+    vertices.sort_by(|left, right| {
+        let left_id = match left {
+            Vertex::INode(node) | Vertex::ENode(node) => node.info.id,
+            Vertex::VNode((_, node_id)) => *node_id,
+        };
+        let right_id = match right {
+            Vertex::INode(node) | Vertex::ENode(node) => node.info.id,
+            Vertex::VNode((_, node_id)) => *node_id,
+        };
+
+        left_id.cmp(&right_id)
+    });
+
+    let contacts = topology
+        .contacts
+        .iter()
+        .filter_map(|contact| {
+            Contact::try_new(
+                ContactInfo::new(
+                    contact.tx_node_id,
+                    contact.rx_node_id,
+                    contact.start,
+                    contact.end,
+                ),
+                EVLManager::new(contact.rate, contact.delay),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    Ok(ContactPlan::new(vertices, contacts, None))
+}
+
+pub fn build_shadow_router(
+    topology: &TopologySnapshot,
+    config: &ShadowEngineConfig,
+) -> Result<ShadowRouter, ASABRError> {
+    let contact_plan = build_contact_plan(topology)?;
+    let route_cache = new_route_cache(config);
+
+    ShadowRouter::new(contact_plan, route_cache, config.check_priority)
 }

--- a/rust-bindings/hardy-a-sabr/src/lib.rs
+++ b/rust-bindings/hardy-a-sabr/src/lib.rs
@@ -1,4 +1,5 @@
 mod agent;
+pub mod engine;
 pub mod projection;
 mod router;
 pub mod routes;

--- a/rust-bindings/hardy-a-sabr/src/lib.rs
+++ b/rust-bindings/hardy-a-sabr/src/lib.rs
@@ -1,4 +1,5 @@
 mod agent;
+pub mod config;
 pub mod engine;
 pub mod projection;
 pub mod refresh;

--- a/rust-bindings/hardy-a-sabr/src/lib.rs
+++ b/rust-bindings/hardy-a-sabr/src/lib.rs
@@ -4,6 +4,7 @@ pub mod projection;
 pub mod refresh;
 mod router;
 pub mod routes;
+mod scheduler;
 pub mod topology;
 
 pub use router::Router;

--- a/rust-bindings/hardy-a-sabr/src/lib.rs
+++ b/rust-bindings/hardy-a-sabr/src/lib.rs
@@ -1,0 +1,3 @@
+mod agent;
+mod router;
+pub mod topology;

--- a/rust-bindings/hardy-a-sabr/src/lib.rs
+++ b/rust-bindings/hardy-a-sabr/src/lib.rs
@@ -5,3 +5,5 @@ pub mod refresh;
 mod router;
 pub mod routes;
 pub mod topology;
+
+pub use router::Router;

--- a/rust-bindings/hardy-a-sabr/src/lib.rs
+++ b/rust-bindings/hardy-a-sabr/src/lib.rs
@@ -1,6 +1,7 @@
 mod agent;
 pub mod engine;
 pub mod projection;
+pub mod refresh;
 mod router;
 pub mod routes;
 pub mod topology;

--- a/rust-bindings/hardy-a-sabr/src/lib.rs
+++ b/rust-bindings/hardy-a-sabr/src/lib.rs
@@ -1,3 +1,5 @@
 mod agent;
+pub mod projection;
 mod router;
+pub mod routes;
 pub mod topology;

--- a/rust-bindings/hardy-a-sabr/src/main.rs
+++ b/rust-bindings/hardy-a-sabr/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/rust-bindings/hardy-a-sabr/src/main.rs
+++ b/rust-bindings/hardy-a-sabr/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/rust-bindings/hardy-a-sabr/src/main.rs
+++ b/rust-bindings/hardy-a-sabr/src/main.rs
@@ -1,6 +1,3 @@
-mod agent;
-mod router;
-
 fn main() {
     println!("Hello, world!");
 }

--- a/rust-bindings/hardy-a-sabr/src/main.rs
+++ b/rust-bindings/hardy-a-sabr/src/main.rs
@@ -1,3 +1,6 @@
+mod agent;
+mod router;
+
 fn main() {
     println!("Hello, world!");
 }

--- a/rust-bindings/hardy-a-sabr/src/projection.rs
+++ b/rust-bindings/hardy-a-sabr/src/projection.rs
@@ -1,0 +1,31 @@
+use hardy_eid_patterns::EidPattern;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RepresentativeBundle {
+    pub size: f64,
+    pub priority: i8,
+    pub expiration_horizon: f64,
+}
+
+impl Default for RepresentativeBundle {
+    fn default() -> Self {
+        Self {
+            size: 1.0,
+            priority: 0,
+            expiration_horizon: 3600.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DestinationProjection {
+    pub pattern: EidPattern,
+    pub asabr_destination: u16,
+    pub route_priority: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ProjectionConfig {
+    pub bundle: RepresentativeBundle,
+    pub destinations: Vec<DestinationProjection>,
+}

--- a/rust-bindings/hardy-a-sabr/src/projection.rs
+++ b/rust-bindings/hardy-a-sabr/src/projection.rs
@@ -11,17 +11,17 @@ use crate::{
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RepresentativeBundle {
-    pub size: f64,
+    pub size: i64,
     pub priority: i8,
-    pub expiration_horizon: f64,
+    pub expiration_horizon: i64,
 }
 
 impl Default for RepresentativeBundle {
     fn default() -> Self {
         Self {
-            size: 1.0,
+            size: 1,
             priority: 0,
-            expiration_horizon: 3600.0,
+            expiration_horizon: 3_600_000,
         }
     }
 }
@@ -46,7 +46,7 @@ pub fn project_routes(
     engine_config: &ShadowEngineConfig,
     config: &ProjectionConfig,
     source: u16,
-    now: f64,
+    now: i64,
 ) -> Result<Vec<ProjectedRoute>, ASABRError> {
     let mut routes = Vec::new();
 

--- a/rust-bindings/hardy-a-sabr/src/projection.rs
+++ b/rust-bindings/hardy-a-sabr/src/projection.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RepresentativeBundle {
     pub size: f64,
     pub priority: i8,
@@ -26,6 +27,7 @@ impl Default for RepresentativeBundle {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestinationProjection {
     pub pattern: EidPattern,
     pub asabr_destination: u16,
@@ -33,6 +35,7 @@ pub struct DestinationProjection {
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ProjectionConfig {
     pub bundle: RepresentativeBundle,
     pub destinations: Vec<DestinationProjection>,

--- a/rust-bindings/hardy-a-sabr/src/projection.rs
+++ b/rust-bindings/hardy-a-sabr/src/projection.rs
@@ -1,4 +1,12 @@
+use a_sabr::errors::ASABRError;
+use hardy_bpa::routing::RouteAction;
 use hardy_eid_patterns::EidPattern;
+
+use crate::{
+    engine::{ShadowEngineConfig, compute_first_hop},
+    routes::ProjectedRoute,
+    topology::TopologySnapshot,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct RepresentativeBundle {
@@ -28,4 +36,40 @@ pub struct DestinationProjection {
 pub struct ProjectionConfig {
     pub bundle: RepresentativeBundle,
     pub destinations: Vec<DestinationProjection>,
+}
+
+pub fn project_routes(
+    topology: &TopologySnapshot,
+    engine_config: &ShadowEngineConfig,
+    config: &ProjectionConfig,
+    source: u16,
+    now: f64,
+) -> Result<Vec<ProjectedRoute>, ASABRError> {
+    let mut routes = Vec::new();
+
+    for destination in &config.destinations {
+        let Some(next_hop) = compute_first_hop(
+            topology,
+            engine_config,
+            source,
+            destination.asabr_destination,
+            now,
+            &config.bundle,
+        )?
+        else {
+            continue;
+        };
+
+        let Some(next_hop_eid) = topology.hardy_eid_for(next_hop) else {
+            continue;
+        };
+
+        routes.push(ProjectedRoute {
+            pattern: destination.pattern.clone(),
+            action: RouteAction::Via(next_hop_eid),
+            priority: destination.route_priority,
+        });
+    }
+
+    Ok(routes)
 }

--- a/rust-bindings/hardy-a-sabr/src/refresh.rs
+++ b/rust-bindings/hardy-a-sabr/src/refresh.rs
@@ -33,7 +33,7 @@ pub async fn refresh_routes(
     engine_config: &ShadowEngineConfig,
     projection_config: &ProjectionConfig,
     source: u16,
-    now: f64,
+    now: i64,
 ) -> Result<(), RefreshError> {
     let desired = project_routes(topology, engine_config, projection_config, source, now)?;
     let diff = diff_routes(installed, &desired);

--- a/rust-bindings/hardy-a-sabr/src/refresh.rs
+++ b/rust-bindings/hardy-a-sabr/src/refresh.rs
@@ -1,0 +1,45 @@
+use a_sabr::errors::ASABRError;
+use hardy_bpa::routing::{self, RoutingSink};
+
+use crate::{
+    engine::ShadowEngineConfig,
+    projection::{ProjectionConfig, project_routes},
+    routes::{ProjectedRoute, apply_route_diff, diff_routes, reconcile_installed_routes},
+    topology::TopologySnapshot,
+};
+
+#[derive(Debug)]
+pub enum RefreshError {
+    Asabr(ASABRError),
+    Hardy(routing::Error),
+}
+
+impl From<ASABRError> for RefreshError {
+    fn from(error: ASABRError) -> Self {
+        Self::Asabr(error)
+    }
+}
+
+impl From<routing::Error> for RefreshError {
+    fn from(error: routing::Error) -> Self {
+        Self::Hardy(error)
+    }
+}
+
+pub async fn refresh_routes(
+    sink: &dyn RoutingSink,
+    installed: &mut Vec<ProjectedRoute>,
+    topology: &TopologySnapshot,
+    engine_config: &ShadowEngineConfig,
+    projection_config: &ProjectionConfig,
+    source: u16,
+    now: f64,
+) -> Result<(), RefreshError> {
+    let desired = project_routes(topology, engine_config, projection_config, source, now)?;
+    let diff = diff_routes(installed, &desired);
+    let accepted = apply_route_diff(sink, &diff).await?;
+
+    reconcile_installed_routes(installed, &diff, accepted);
+
+    Ok(())
+}

--- a/rust-bindings/hardy-a-sabr/src/router.rs
+++ b/rust-bindings/hardy-a-sabr/src/router.rs
@@ -1,0 +1,1 @@
+pub struct Router {}

--- a/rust-bindings/hardy-a-sabr/src/router.rs
+++ b/rust-bindings/hardy-a-sabr/src/router.rs
@@ -3,7 +3,10 @@ use std::sync::{Arc, Mutex};
 use hardy_bpa::routing::RoutingSink;
 
 use crate::{
-    engine::ShadowEngineConfig, projection::ProjectionConfig, routes::ProjectedRoute,
+    engine::ShadowEngineConfig,
+    projection::ProjectionConfig,
+    refresh::{RefreshError, refresh_routes},
+    routes::ProjectedRoute,
     topology::TopologySnapshot,
 };
 
@@ -34,5 +37,30 @@ impl Router {
     pub fn with_engine_config(mut self, engine_config: ShadowEngineConfig) -> Self {
         self.engine_config = engine_config;
         self
+    }
+
+    pub(crate) async fn refresh_with_sink(
+        &self,
+        sink: &dyn RoutingSink,
+        now: f64,
+    ) -> Result<(), RefreshError> {
+        let topology = self.topology.lock().unwrap().clone();
+        let mut installed = self.installed.lock().unwrap().clone();
+
+        refresh_routes(
+            sink,
+            &mut installed,
+            &topology,
+            &self.engine_config,
+            &self.projection_config,
+            self.source,
+            now,
+        )
+        .await?;
+
+        let mut stored_installed = self.installed.lock().unwrap();
+        *stored_installed = installed;
+
+        Ok(())
     }
 }

--- a/rust-bindings/hardy-a-sabr/src/router.rs
+++ b/rust-bindings/hardy-a-sabr/src/router.rs
@@ -1,4 +1,4 @@
-use std::sync::Mutex;
+use std::{sync::Mutex, time::Duration};
 
 use crate::{
     engine::ShadowEngineConfig, projection::ProjectionConfig, scheduler::SchedulerHandle,
@@ -12,6 +12,7 @@ pub struct Router {
     pub(crate) projection_config: ProjectionConfig,
     pub(crate) scheduler: Mutex<Option<SchedulerHandle>>,
     pub(crate) start_time: f64,
+    pub(crate) safety_tick: Duration,
 }
 
 impl Router {
@@ -27,7 +28,13 @@ impl Router {
             projection_config,
             scheduler: Mutex::new(None),
             start_time: 0.0,
+            safety_tick: Duration::from_secs(60),
         }
+    }
+
+    pub fn with_safety_tick(mut self, safety_tick: Duration) -> Self {
+        self.safety_tick = safety_tick;
+        self
     }
 
     pub fn with_start_time(mut self, start_time: f64) -> Self {

--- a/rust-bindings/hardy-a-sabr/src/router.rs
+++ b/rust-bindings/hardy-a-sabr/src/router.rs
@@ -31,4 +31,15 @@ impl Router {
         self.engine_config = engine_config;
         self
     }
+
+    pub async fn update_topology(&self, topology: TopologySnapshot) {
+        {
+            let mut stored_topology = self.topology.lock().unwrap();
+            *stored_topology = topology.clone();
+        }
+        let scheduler = self.scheduler.lock().unwrap().clone();
+        if let Some(scheduler) = scheduler {
+            scheduler.update_topology(topology).await
+        }
+    }
 }

--- a/rust-bindings/hardy-a-sabr/src/router.rs
+++ b/rust-bindings/hardy-a-sabr/src/router.rs
@@ -11,7 +11,7 @@ pub struct Router {
     pub(crate) engine_config: ShadowEngineConfig,
     pub(crate) projection_config: ProjectionConfig,
     pub(crate) scheduler: Mutex<Option<SchedulerHandle>>,
-    pub(crate) start_time: f64,
+    pub(crate) start_time: i64,
     pub(crate) safety_tick: Duration,
 }
 
@@ -27,7 +27,7 @@ impl Router {
             engine_config: ShadowEngineConfig::default(),
             projection_config,
             scheduler: Mutex::new(None),
-            start_time: 0.0,
+            start_time: 0,
             safety_tick: Duration::from_secs(60),
         }
     }
@@ -37,7 +37,7 @@ impl Router {
         self
     }
 
-    pub fn with_start_time(mut self, start_time: f64) -> Self {
+    pub fn with_start_time(mut self, start_time: i64) -> Self {
         self.start_time = start_time;
         self
     }

--- a/rust-bindings/hardy-a-sabr/src/router.rs
+++ b/rust-bindings/hardy-a-sabr/src/router.rs
@@ -1,1 +1,34 @@
-pub struct Router {}
+use std::sync::Mutex;
+
+use crate::{
+    engine::ShadowEngineConfig, projection::ProjectionConfig, routes::ProjectedRoute,
+    topology::TopologySnapshot,
+};
+
+pub struct Router {
+    pub(crate) source: u16,
+    pub(crate) topology: Mutex<TopologySnapshot>,
+    pub(crate) engine_config: ShadowEngineConfig,
+    pub(crate) projection_config: ProjectionConfig,
+    pub(crate) installed: Mutex<Vec<ProjectedRoute>>,
+}
+
+impl Router {
+    pub fn new(
+        source: u16,
+        topology: TopologySnapshot,
+        projection_config: ProjectionConfig,
+    ) -> Self {
+        Self {
+            source,
+            topology: Mutex::new(topology),
+            engine_config: ShadowEngineConfig::default(),
+            projection_config,
+            installed: Mutex::new(Vec::new()),
+        }
+    }
+    pub fn with_engine_config(mut self, engine_config: ShadowEngineConfig) -> Self {
+        self.engine_config = engine_config;
+        self
+    }
+}

--- a/rust-bindings/hardy-a-sabr/src/router.rs
+++ b/rust-bindings/hardy-a-sabr/src/router.rs
@@ -1,12 +1,7 @@
-use std::sync::{Arc, Mutex};
-
-use hardy_bpa::routing::RoutingSink;
+use std::sync::Mutex;
 
 use crate::{
-    engine::ShadowEngineConfig,
-    projection::ProjectionConfig,
-    refresh::{RefreshError, refresh_routes},
-    routes::ProjectedRoute,
+    engine::ShadowEngineConfig, projection::ProjectionConfig, scheduler::SchedulerHandle,
     topology::TopologySnapshot,
 };
 
@@ -15,8 +10,7 @@ pub struct Router {
     pub(crate) topology: Mutex<TopologySnapshot>,
     pub(crate) engine_config: ShadowEngineConfig,
     pub(crate) projection_config: ProjectionConfig,
-    pub(crate) installed: Mutex<Vec<ProjectedRoute>>,
-    pub(crate) sink: Mutex<Option<Arc<dyn RoutingSink>>>,
+    pub(crate) scheduler: Mutex<Option<SchedulerHandle>>,
 }
 
 impl Router {
@@ -30,37 +24,11 @@ impl Router {
             topology: Mutex::new(topology),
             engine_config: ShadowEngineConfig::default(),
             projection_config,
-            installed: Mutex::new(Vec::new()),
-            sink: Mutex::new(None),
+            scheduler: Mutex::new(None),
         }
     }
     pub fn with_engine_config(mut self, engine_config: ShadowEngineConfig) -> Self {
         self.engine_config = engine_config;
         self
-    }
-
-    pub(crate) async fn refresh_with_sink(
-        &self,
-        sink: &dyn RoutingSink,
-        now: f64,
-    ) -> Result<(), RefreshError> {
-        let topology = self.topology.lock().unwrap().clone();
-        let mut installed = self.installed.lock().unwrap().clone();
-
-        refresh_routes(
-            sink,
-            &mut installed,
-            &topology,
-            &self.engine_config,
-            &self.projection_config,
-            self.source,
-            now,
-        )
-        .await?;
-
-        let mut stored_installed = self.installed.lock().unwrap();
-        *stored_installed = installed;
-
-        Ok(())
     }
 }

--- a/rust-bindings/hardy-a-sabr/src/router.rs
+++ b/rust-bindings/hardy-a-sabr/src/router.rs
@@ -11,6 +11,7 @@ pub struct Router {
     pub(crate) engine_config: ShadowEngineConfig,
     pub(crate) projection_config: ProjectionConfig,
     pub(crate) scheduler: Mutex<Option<SchedulerHandle>>,
+    pub(crate) start_time: f64,
 }
 
 impl Router {
@@ -25,8 +26,15 @@ impl Router {
             engine_config: ShadowEngineConfig::default(),
             projection_config,
             scheduler: Mutex::new(None),
+            start_time: 0.0,
         }
     }
+
+    pub fn with_start_time(mut self, start_time: f64) -> Self {
+        self.start_time = start_time;
+        self
+    }
+
     pub fn with_engine_config(mut self, engine_config: ShadowEngineConfig) -> Self {
         self.engine_config = engine_config;
         self

--- a/rust-bindings/hardy-a-sabr/src/router.rs
+++ b/rust-bindings/hardy-a-sabr/src/router.rs
@@ -1,4 +1,6 @@
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
+
+use hardy_bpa::routing::RoutingSink;
 
 use crate::{
     engine::ShadowEngineConfig, projection::ProjectionConfig, routes::ProjectedRoute,
@@ -11,6 +13,7 @@ pub struct Router {
     pub(crate) engine_config: ShadowEngineConfig,
     pub(crate) projection_config: ProjectionConfig,
     pub(crate) installed: Mutex<Vec<ProjectedRoute>>,
+    pub(crate) sink: Mutex<Option<Arc<dyn RoutingSink>>>,
 }
 
 impl Router {
@@ -25,6 +28,7 @@ impl Router {
             engine_config: ShadowEngineConfig::default(),
             projection_config,
             installed: Mutex::new(Vec::new()),
+            sink: Mutex::new(None),
         }
     }
     pub fn with_engine_config(mut self, engine_config: ShadowEngineConfig) -> Self {

--- a/rust-bindings/hardy-a-sabr/src/router.rs
+++ b/rust-bindings/hardy-a-sabr/src/router.rs
@@ -50,4 +50,11 @@ impl Router {
             scheduler.update_topology(topology).await
         }
     }
+
+    pub async fn refresh(&self) {
+        let scheduler = self.scheduler.lock().unwrap().clone();
+        if let Some(scheduler) = scheduler {
+            scheduler.refresh().await;
+        }
+    }
 }

--- a/rust-bindings/hardy-a-sabr/src/routes.rs
+++ b/rust-bindings/hardy-a-sabr/src/routes.rs
@@ -1,4 +1,4 @@
-use hardy_bpa::routing::RouteAction;
+use hardy_bpa::routing::{self, RouteAction, RoutingSink};
 use hardy_eid_patterns::EidPattern;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -28,4 +28,34 @@ pub fn diff_routes(installed: &[ProjectedRoute], desired: &[ProjectedRoute]) -> 
         .collect();
 
     RouteDiff { remove, add }
+}
+
+pub async fn apply_route_diff(
+    sink: &dyn RoutingSink,
+    diff: &RouteDiff,
+) -> routing::Result<Vec<ProjectedRoute>> {
+    let mut accepted = Vec::new();
+
+    for route in &diff.remove {
+        sink.remove_route(&route.pattern, &route.action, route.priority)
+            .await?;
+    }
+
+    for route in &diff.add {
+        sink.add_route(route.pattern.clone(), route.action.clone(), route.priority)
+            .await?;
+
+        accepted.push(route.clone());
+    }
+
+    Ok(accepted)
+}
+
+pub fn reconcile_installed_routes(
+    installed: &mut Vec<ProjectedRoute>,
+    diff: &RouteDiff,
+    accepted: Vec<ProjectedRoute>,
+) {
+    installed.retain(|route| !diff.remove.iter().any(|removed| removed == route));
+    installed.extend(accepted);
 }

--- a/rust-bindings/hardy-a-sabr/src/routes.rs
+++ b/rust-bindings/hardy-a-sabr/src/routes.rs
@@ -1,0 +1,31 @@
+use hardy_bpa::routing::RouteAction;
+use hardy_eid_patterns::EidPattern;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectedRoute {
+    pub pattern: EidPattern,
+    pub action: RouteAction,
+    pub priority: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct RouteDiff {
+    pub remove: Vec<ProjectedRoute>,
+    pub add: Vec<ProjectedRoute>,
+}
+
+pub fn diff_routes(installed: &[ProjectedRoute], desired: &[ProjectedRoute]) -> RouteDiff {
+    let remove = installed
+        .iter()
+        .filter(|route| !desired.iter().any(|desired| desired == *route))
+        .cloned()
+        .collect();
+
+    let add = desired
+        .iter()
+        .filter(|route| !installed.iter().any(|installed| installed == *route))
+        .cloned()
+        .collect();
+
+    RouteDiff { remove, add }
+}

--- a/rust-bindings/hardy-a-sabr/src/scheduler.rs
+++ b/rust-bindings/hardy-a-sabr/src/scheduler.rs
@@ -1,0 +1,79 @@
+use std::sync::Arc;
+
+use hardy_async::{CancellationToken, JoinHandle, channel};
+use hardy_bpa::routing::RoutingSink;
+
+use crate::topology::TopologySnapshot;
+
+#[derive(Debug)]
+pub(crate) enum SchedulerCommand {
+    Refresh,
+    TopologyChanged(TopologySnapshot),
+    Shutdown,
+}
+
+struct SchedulerHandle {
+    sender: channel::Sender<SchedulerCommand>,
+    cancel: CancellationToken,
+}
+
+impl SchedulerHandle {
+    pub(crate) async fn refresh(&self) {
+        let _ = self.sender.send(SchedulerCommand::Refresh).await;
+    }
+
+    pub(crate) async fn update_topology(&self, topology: TopologySnapshot) {
+        let _ = self
+            .sender
+            .send(SchedulerCommand::TopologyChanged(topology))
+            .await;
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        let _ = self.sender.send(SchedulerCommand::Shutdown).await;
+        self.cancel.cancel();
+    }
+}
+
+pub(crate) struct Scheduler {
+    sink: Arc<dyn RoutingSink>,
+    receiver: channel::Receiver<SchedulerCommand>,
+    cancel: CancellationToken,
+}
+
+impl Scheduler {
+    pub(crate) fn new(sink: Arc<dyn RoutingSink>) -> (Self, SchedulerHandle) {
+        let (sender, receiver) = channel::unbounded();
+        let cancel = CancellationToken::new();
+        let scheduler = Self {
+            sink,
+            receiver,
+            cancel: cancel.clone(),
+        };
+
+        let handle = SchedulerHandle { sender, cancel };
+        (scheduler, handle)
+    }
+
+    pub(crate) fn start(self) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            self.run().await;
+        })
+    }
+
+    async fn run(self) {
+        loop {
+            tokio::select! {
+                _ = self.cancel.cancelled() => break,
+                command = self.receiver.recv() =>{
+                    match command{
+                        Ok(SchedulerCommand::Refresh)=> {},
+                        Ok(SchedulerCommand::TopologyChanged(_topology))=> {},
+                        Ok(SchedulerCommand::Shutdown)=> {},
+                        Err(_) => break,
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rust-bindings/hardy-a-sabr/src/scheduler.rs
+++ b/rust-bindings/hardy-a-sabr/src/scheduler.rs
@@ -54,16 +54,17 @@ pub(crate) struct Scheduler {
     installed: Vec<ProjectedRoute>,
     started_at: tokio::time::Instant,
     safety_tick: Duration,
+    start_time: f64,
 }
 
 impl Scheduler {
     pub(crate) fn new(
         sink: Arc<dyn RoutingSink>,
-
         source: u16,
         topology: TopologySnapshot,
         engine_config: ShadowEngineConfig,
         projection_config: ProjectionConfig,
+        start_time: f64,
     ) -> (Self, SchedulerHandle) {
         let (sender, receiver) = channel::unbounded();
         let cancel = CancellationToken::new();
@@ -78,6 +79,7 @@ impl Scheduler {
             installed: Vec::new(),
             started_at: tokio::time::Instant::now(),
             safety_tick: Duration::from_secs(60),
+            start_time,
         };
 
         let handle = SchedulerHandle { sender, cancel };
@@ -85,7 +87,7 @@ impl Scheduler {
     }
 
     fn now(&self) -> f64 {
-        self.started_at.elapsed().as_secs_f64()
+        self.start_time + self.started_at.elapsed().as_secs_f64()
     }
 
     fn next_boundary_delay(&self, now: f64) -> Option<Duration> {

--- a/rust-bindings/hardy-a-sabr/src/scheduler.rs
+++ b/rust-bindings/hardy-a-sabr/src/scheduler.rs
@@ -65,6 +65,7 @@ impl Scheduler {
         engine_config: ShadowEngineConfig,
         projection_config: ProjectionConfig,
         start_time: f64,
+        safety_tick: Duration,
     ) -> (Self, SchedulerHandle) {
         let (sender, receiver) = channel::unbounded();
         let cancel = CancellationToken::new();
@@ -78,7 +79,7 @@ impl Scheduler {
             projection_config,
             installed: Vec::new(),
             started_at: tokio::time::Instant::now(),
-            safety_tick: Duration::from_secs(60),
+            safety_tick,
             start_time,
         };
 

--- a/rust-bindings/hardy-a-sabr/src/scheduler.rs
+++ b/rust-bindings/hardy-a-sabr/src/scheduler.rs
@@ -54,7 +54,7 @@ pub(crate) struct Scheduler {
     installed: Vec<ProjectedRoute>,
     started_at: tokio::time::Instant,
     safety_tick: Duration,
-    start_time: f64,
+    start_time: i64,
 }
 
 impl Scheduler {
@@ -64,7 +64,7 @@ impl Scheduler {
         topology: TopologySnapshot,
         engine_config: ShadowEngineConfig,
         projection_config: ProjectionConfig,
-        start_time: f64,
+        start_time: i64,
         safety_tick: Duration,
     ) -> (Self, SchedulerHandle) {
         let (sender, receiver) = channel::unbounded();
@@ -87,17 +87,17 @@ impl Scheduler {
         (scheduler, handle)
     }
 
-    fn now(&self) -> f64 {
-        self.start_time + self.started_at.elapsed().as_secs_f64()
+    fn now(&self) -> i64 {
+        self.start_time + self.started_at.elapsed().as_millis() as i64
     }
 
-    fn next_boundary_delay(&self, now: f64) -> Option<Duration> {
+    fn next_boundary_delay(&self, now: i64) -> Option<Duration> {
         self.topology
             .next_boundary_after(now)
-            .map(|boundary| Duration::from_secs_f64((boundary - now).max(0.0)))
+            .map(|boundary| Duration::from_millis((boundary - now).max(0) as u64))
     }
 
-    fn next_wakeup_delay(&self, now: f64) -> Duration {
+    fn next_wakeup_delay(&self, now: i64) -> Duration {
         self.next_boundary_delay(now)
             .map(|boundary_delay| boundary_delay.min(self.safety_tick))
             .unwrap_or(self.safety_tick)
@@ -128,7 +128,7 @@ impl Scheduler {
         self.withdraw().await;
     }
 
-    async fn refresh(&mut self, now: f64) {
+    async fn refresh(&mut self, now: i64) {
         if let Err(error) = refresh_routes(
             &*self.sink,
             &mut self.installed,

--- a/rust-bindings/hardy-a-sabr/src/scheduler.rs
+++ b/rust-bindings/hardy-a-sabr/src/scheduler.rs
@@ -3,7 +3,13 @@ use std::sync::Arc;
 use hardy_async::{CancellationToken, JoinHandle, channel};
 use hardy_bpa::routing::RoutingSink;
 
-use crate::topology::TopologySnapshot;
+use crate::{
+    engine::ShadowEngineConfig,
+    projection::ProjectionConfig,
+    refresh::refresh_routes,
+    routes::{ProjectedRoute, apply_route_diff, diff_routes},
+    topology::TopologySnapshot,
+};
 
 #[derive(Debug)]
 pub(crate) enum SchedulerCommand {
@@ -12,7 +18,7 @@ pub(crate) enum SchedulerCommand {
     Shutdown,
 }
 
-struct SchedulerHandle {
+pub(crate) struct SchedulerHandle {
     sender: channel::Sender<SchedulerCommand>,
     cancel: CancellationToken,
 }
@@ -39,16 +45,33 @@ pub(crate) struct Scheduler {
     sink: Arc<dyn RoutingSink>,
     receiver: channel::Receiver<SchedulerCommand>,
     cancel: CancellationToken,
+    source: u16,
+    topology: TopologySnapshot,
+    engine_config: ShadowEngineConfig,
+    projection_config: ProjectionConfig,
+    installed: Vec<ProjectedRoute>,
 }
 
 impl Scheduler {
-    pub(crate) fn new(sink: Arc<dyn RoutingSink>) -> (Self, SchedulerHandle) {
+    pub(crate) fn new(
+        sink: Arc<dyn RoutingSink>,
+
+        source: u16,
+        topology: TopologySnapshot,
+        engine_config: ShadowEngineConfig,
+        projection_config: ProjectionConfig,
+    ) -> (Self, SchedulerHandle) {
         let (sender, receiver) = channel::unbounded();
         let cancel = CancellationToken::new();
         let scheduler = Self {
             sink,
             receiver,
             cancel: cancel.clone(),
+            source,
+            topology,
+            engine_config,
+            projection_config,
+            installed: Vec::new(),
         };
 
         let handle = SchedulerHandle { sender, cancel };
@@ -61,19 +84,56 @@ impl Scheduler {
         })
     }
 
-    async fn run(self) {
+    async fn run(mut self) {
         loop {
             tokio::select! {
                 _ = self.cancel.cancelled() => break,
                 command = self.receiver.recv() =>{
                     match command{
-                        Ok(SchedulerCommand::Refresh)=> {},
-                        Ok(SchedulerCommand::TopologyChanged(_topology))=> {},
-                        Ok(SchedulerCommand::Shutdown)=> {},
+                        Ok(SchedulerCommand::Refresh)=> {
+                            self.refresh(0.0).await;
+                        },
+                        Ok(SchedulerCommand::TopologyChanged(topology))=> {
+                            self.topology = topology;
+                            self.refresh(0.0).await;
+                        },
+                        Ok(SchedulerCommand::Shutdown)=> break,
                         Err(_) => break,
                     }
                 }
             }
         }
+        self.withdraw().await;
+    }
+
+    async fn refresh(&mut self, now: f64) {
+        if let Err(error) = refresh_routes(
+            &*self.sink,
+            &mut self.installed,
+            &self.topology,
+            &self.engine_config,
+            &self.projection_config,
+            self.source,
+            now,
+        )
+        .await
+        {
+            eprintln!(
+                "A-SABR scheduled route refresh failed:
+          {error:?}"
+            );
+        }
+    }
+
+    async fn withdraw(&mut self) {
+        let diff = diff_routes(&self.installed, &[]);
+        if let Err(error) = apply_route_diff(&*self.sink, &diff).await {
+            eprintln!(
+                "A-SABR scheduled route withdrawal failed:
+          {error:?}"
+            );
+            return;
+        };
+        self.installed.clear();
     }
 }

--- a/rust-bindings/hardy-a-sabr/src/scheduler.rs
+++ b/rust-bindings/hardy-a-sabr/src/scheduler.rs
@@ -11,13 +11,14 @@ use crate::{
     topology::TopologySnapshot,
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum SchedulerCommand {
     Refresh,
     TopologyChanged(TopologySnapshot),
     Shutdown,
 }
 
+#[derive(Clone)]
 pub(crate) struct SchedulerHandle {
     sender: channel::Sender<SchedulerCommand>,
     cancel: CancellationToken,

--- a/rust-bindings/hardy-a-sabr/src/scheduler.rs
+++ b/rust-bindings/hardy-a-sabr/src/scheduler.rs
@@ -9,7 +9,7 @@ use crate::{
     projection::ProjectionConfig,
     refresh::refresh_routes,
     routes::{ProjectedRoute, apply_route_diff, diff_routes},
-    topology::{self, TopologySnapshot},
+    topology::TopologySnapshot,
 };
 
 #[derive(Clone, Debug)]
@@ -53,6 +53,7 @@ pub(crate) struct Scheduler {
     projection_config: ProjectionConfig,
     installed: Vec<ProjectedRoute>,
     started_at: tokio::time::Instant,
+    safety_tick: Duration,
 }
 
 impl Scheduler {
@@ -76,6 +77,7 @@ impl Scheduler {
             projection_config,
             installed: Vec::new(),
             started_at: tokio::time::Instant::now(),
+            safety_tick: Duration::from_secs(60),
         };
 
         let handle = SchedulerHandle { sender, cancel };
@@ -92,6 +94,12 @@ impl Scheduler {
             .map(|boundary| Duration::from_secs_f64((boundary - now).max(0.0)))
     }
 
+    fn next_wakeup_delay(&self, now: f64) -> Duration {
+        self.next_boundary_delay(now)
+            .map(|boundary_delay| boundary_delay.min(self.safety_tick))
+            .unwrap_or(self.safety_tick)
+    }
+
     pub(crate) fn start(self) -> JoinHandle<()> {
         tokio::spawn(async move {
             self.run().await;
@@ -100,30 +108,18 @@ impl Scheduler {
 
     async fn run(mut self) {
         loop {
-            let now = self.now();
+            let delay = self.next_wakeup_delay(self.now());
 
-            match self.next_boundary_delay(now) {
-                Some(delay) => {
-                    tokio::select! {
-                        _ = self.cancel.cancelled() => break,
-                        _ = tokio::time::sleep(delay) =>{
-                        self.refresh(self.now()).await;
-                    }
-                    command = self.receiver.recv() => {
-                            if !self.handle_command(command).await {
-                                break;
-                            }
-                        }
+            tokio::select! {
+                _ = self.cancel.cancelled() => break,
+                _ = tokio::time::sleep(delay) =>{
+                self.refresh(self.now()).await;
+            }
+            command = self.receiver.recv() => {
+                    if !self.handle_command(command).await {
+                        break;
                     }
                 }
-                None => tokio::select! {
-                    _ = self.cancel.cancelled()=> break,
-                    command = self.receiver.recv()=>{
-                        if !self.handle_command(command).await{
-                            break;
-                        }
-                    }
-                },
             }
         }
         self.withdraw().await;

--- a/rust-bindings/hardy-a-sabr/src/scheduler.rs
+++ b/rust-bindings/hardy-a-sabr/src/scheduler.rs
@@ -1,14 +1,15 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use hardy_async::{CancellationToken, JoinHandle, channel};
 use hardy_bpa::routing::RoutingSink;
+use tracing::warn;
 
 use crate::{
     engine::ShadowEngineConfig,
     projection::ProjectionConfig,
     refresh::refresh_routes,
     routes::{ProjectedRoute, apply_route_diff, diff_routes},
-    topology::TopologySnapshot,
+    topology::{self, TopologySnapshot},
 };
 
 #[derive(Clone, Debug)]
@@ -51,6 +52,7 @@ pub(crate) struct Scheduler {
     engine_config: ShadowEngineConfig,
     projection_config: ProjectionConfig,
     installed: Vec<ProjectedRoute>,
+    started_at: tokio::time::Instant,
 }
 
 impl Scheduler {
@@ -73,10 +75,21 @@ impl Scheduler {
             engine_config,
             projection_config,
             installed: Vec::new(),
+            started_at: tokio::time::Instant::now(),
         };
 
         let handle = SchedulerHandle { sender, cancel };
         (scheduler, handle)
+    }
+
+    fn now(&self) -> f64 {
+        self.started_at.elapsed().as_secs_f64()
+    }
+
+    fn next_boundary_delay(&self, now: f64) -> Option<Duration> {
+        self.topology
+            .next_boundary_after(now)
+            .map(|boundary| Duration::from_secs_f64((boundary - now).max(0.0)))
     }
 
     pub(crate) fn start(self) -> JoinHandle<()> {
@@ -87,21 +100,30 @@ impl Scheduler {
 
     async fn run(mut self) {
         loop {
-            tokio::select! {
-                _ = self.cancel.cancelled() => break,
-                command = self.receiver.recv() =>{
-                    match command{
-                        Ok(SchedulerCommand::Refresh)=> {
-                            self.refresh(0.0).await;
-                        },
-                        Ok(SchedulerCommand::TopologyChanged(topology))=> {
-                            self.topology = topology;
-                            self.refresh(0.0).await;
-                        },
-                        Ok(SchedulerCommand::Shutdown)=> break,
-                        Err(_) => break,
+            let now = self.now();
+
+            match self.next_boundary_delay(now) {
+                Some(delay) => {
+                    tokio::select! {
+                        _ = self.cancel.cancelled() => break,
+                        _ = tokio::time::sleep(delay) =>{
+                        self.refresh(self.now()).await;
+                    }
+                    command = self.receiver.recv() => {
+                            if !self.handle_command(command).await {
+                                break;
+                            }
+                        }
                     }
                 }
+                None => tokio::select! {
+                    _ = self.cancel.cancelled()=> break,
+                    command = self.receiver.recv()=>{
+                        if !self.handle_command(command).await{
+                            break;
+                        }
+                    }
+                },
             }
         }
         self.withdraw().await;
@@ -119,22 +141,34 @@ impl Scheduler {
         )
         .await
         {
-            eprintln!(
-                "A-SABR scheduled route refresh failed:
-          {error:?}"
-            );
+            warn!(?error, "A-SABR scheduled route refresh failed");
         }
     }
 
     async fn withdraw(&mut self) {
         let diff = diff_routes(&self.installed, &[]);
         if let Err(error) = apply_route_diff(&*self.sink, &diff).await {
-            eprintln!(
-                "A-SABR scheduled route withdrawal failed:
-          {error:?}"
-            );
+            warn!(?error, "A-SABR scheduled route withdrawal failed");
             return;
         };
         self.installed.clear();
+    }
+
+    async fn handle_command(
+        &mut self,
+        command: Result<SchedulerCommand, channel::RecvError>,
+    ) -> bool {
+        match command {
+            Ok(SchedulerCommand::Refresh) => {
+                self.refresh(self.now()).await;
+                true
+            }
+            Ok(SchedulerCommand::TopologyChanged(topology)) => {
+                self.topology = topology;
+                self.refresh(self.now()).await;
+                true
+            }
+            Ok(SchedulerCommand::Shutdown) | Err(_) => false,
+        }
     }
 }

--- a/rust-bindings/hardy-a-sabr/src/topology.rs
+++ b/rust-bindings/hardy-a-sabr/src/topology.rs
@@ -5,10 +5,10 @@ use hardy_bpv7::eid::{Eid, NodeId};
 pub struct ContactWindow {
     pub tx_node_id: u16,
     pub rx_node_id: u16,
-    pub start: f64,
-    pub end: f64,
-    pub rate: f64,
-    pub delay: f64,
+    pub start: i64,
+    pub end: i64,
+    pub rate: i64,
+    pub delay: i64,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -33,11 +33,11 @@ impl TopologySnapshot {
             .map(|node| node.hardy_node_id.clone().into())
     }
 
-    pub fn next_boundary_after(&self, now: f64) -> Option<f64> {
+    pub fn next_boundary_after(&self, now: i64) -> Option<i64> {
         self.contacts
             .iter()
             .flat_map(|contact| [contact.start, contact.end])
             .filter(|boundary| *boundary > now)
-            .min_by(|a, b| a.total_cmp(b))
+            .min()
     }
 }

--- a/rust-bindings/hardy-a-sabr/src/topology.rs
+++ b/rust-bindings/hardy-a-sabr/src/topology.rs
@@ -1,3 +1,5 @@
+use hardy_bpv7::eid::{Eid, NodeId};
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ContactWindow {
     pub tx_node_id: u16,
@@ -8,12 +10,26 @@ pub struct ContactWindow {
     pub delay: f64,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct NodeMapping {
+    pub asabr_node_id: u16,
+    pub hardy_node_id: NodeId,
+}
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct TopologySnapshot {
+    pub nodes: Vec<NodeMapping>,
     pub contacts: Vec<ContactWindow>,
 }
 
 impl TopologySnapshot {
+    pub fn hardy_eid_for(&self, asabr_node_id: u16) -> Option<Eid> {
+        self.nodes
+            .iter()
+            .find(|node| node.asabr_node_id == asabr_node_id)
+            .map(|node| node.hardy_node_id.clone().into())
+    }
+
     pub fn next_boundary_after(&self, now: f64) -> Option<f64> {
         self.contacts
             .iter()

--- a/rust-bindings/hardy-a-sabr/src/topology.rs
+++ b/rust-bindings/hardy-a-sabr/src/topology.rs
@@ -1,6 +1,7 @@
 use hardy_bpv7::eid::{Eid, NodeId};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ContactWindow {
     pub tx_node_id: u16,
     pub rx_node_id: u16,
@@ -11,12 +12,14 @@ pub struct ContactWindow {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NodeMapping {
     pub asabr_node_id: u16,
     pub hardy_node_id: NodeId,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TopologySnapshot {
     pub nodes: Vec<NodeMapping>,
     pub contacts: Vec<ContactWindow>,

--- a/rust-bindings/hardy-a-sabr/src/topology.rs
+++ b/rust-bindings/hardy-a-sabr/src/topology.rs
@@ -1,0 +1,24 @@
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ContactWindow {
+    pub tx_node_id: u16,
+    pub rx_node_id: u16,
+    pub start: f64,
+    pub end: f64,
+    pub rate: f64,
+    pub delay: f64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TopologySnapshot {
+    pub contacts: Vec<ContactWindow>,
+}
+
+impl TopologySnapshot {
+    pub fn next_boundary_after(&self, now: f64) -> Option<f64> {
+        self.contacts
+            .iter()
+            .flat_map(|contact| [contact.start, contact.end])
+            .filter(|boundary| *boundary > now)
+            .min_by(|a, b| a.total_cmp(b))
+    }
+}

--- a/rust-bindings/hardy-cspcl/Cargo.toml
+++ b/rust-bindings/hardy-cspcl/Cargo.toml
@@ -13,7 +13,6 @@ serde = ["dep:serde", "hardy-bpv7/serde"]
 instrument = ["tracing/attributes"]
 
 [dependencies]
-tracing = { version = "0.1.44", default-features = false }
 thiserror = "2.0.18"
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 cspcl-bindings = { path = "../cspcl", package = "cspcl" }
@@ -23,3 +22,4 @@ hardy-bpa.workspace = true
 hardy-async.workspace = true
 hardy-bpv7.workspace = true
 tokio.workspace = true
+tracing.workspace = true

--- a/rust-bindings/hardy-cspcl/Cargo.toml
+++ b/rust-bindings/hardy-cspcl/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "hardy-cspcl"
+version = "0.1.0"
+edition.workspace = true
+
+[lib]
+path = "src/lib.rs"
+crate-type = ["rlib"]
+
+[features]
+default = []
+serde = ["dep:serde", "hardy-bpv7/serde"]
+instrument = ["tracing/attributes"]
+
+[dependencies]
+hardy-bpa = { git = "https://github.com/ricktaylor/hardy.git" }
+hardy-async = { git = "https://github.com/ricktaylor/hardy.git" }
+hardy-bpv7 = { git = "https://github.com/ricktaylor/hardy.git" }
+tracing = { version = "0.1.44", default-features = false }
+thiserror = "2.0.18"
+tokio = { version = "1.51.1", features = ["time"] }
+serde = { version = "1.0.228", features = ["derive"], optional = true }
+cspcl-bindings = { path = "../cspcl", package = "cspcl" }
+futures-util = "0.3.32"

--- a/rust-bindings/hardy-cspcl/Cargo.toml
+++ b/rust-bindings/hardy-cspcl/Cargo.toml
@@ -15,7 +15,6 @@ instrument = ["tracing/attributes"]
 [dependencies]
 tracing = { version = "0.1.44", default-features = false }
 thiserror = "2.0.18"
-tokio = { version = "1.51.1", features = ["time"] }
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 cspcl-bindings = { path = "../cspcl", package = "cspcl" }
 futures-util = "0.3.32"
@@ -23,3 +22,4 @@ bytes = "1.12.0"
 hardy-bpa.workspace = true
 hardy-async.workspace = true
 hardy-bpv7.workspace = true
+tokio.workspace = true

--- a/rust-bindings/hardy-cspcl/Cargo.toml
+++ b/rust-bindings/hardy-cspcl/Cargo.toml
@@ -22,3 +22,4 @@ tokio = { version = "1.51.1", features = ["time"] }
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 cspcl-bindings = { path = "../cspcl", package = "cspcl" }
 futures-util = "0.3.32"
+bytes = "1.12.0"

--- a/rust-bindings/hardy-cspcl/Cargo.toml
+++ b/rust-bindings/hardy-cspcl/Cargo.toml
@@ -13,9 +13,6 @@ serde = ["dep:serde", "hardy-bpv7/serde"]
 instrument = ["tracing/attributes"]
 
 [dependencies]
-hardy-bpa = { git = "https://github.com/ricktaylor/hardy.git" }
-hardy-async = { git = "https://github.com/ricktaylor/hardy.git" }
-hardy-bpv7 = { git = "https://github.com/ricktaylor/hardy.git" }
 tracing = { version = "0.1.44", default-features = false }
 thiserror = "2.0.18"
 tokio = { version = "1.51.1", features = ["time"] }
@@ -23,3 +20,6 @@ serde = { version = "1.0.228", features = ["derive"], optional = true }
 cspcl-bindings = { path = "../cspcl", package = "cspcl" }
 futures-util = "0.3.32"
 bytes = "1.12.0"
+hardy-bpa.workspace = true
+hardy-async.workspace = true
+hardy-bpv7.workspace = true

--- a/rust-bindings/hardy-cspcl/src/cla.rs
+++ b/rust-bindings/hardy-cspcl/src/cla.rs
@@ -15,6 +15,9 @@ impl cla::Cla for Cla {
 
     async fn on_register(&self, sink: Box<dyn cla::Sink>, _node_ids: &[NodeId]) {
         self.sink.call_once(|| sink.into());
+        self.register_peers()
+            .await
+            .expect("Sink must be registered at this point");
     }
 
     async fn on_unregister(&self) {

--- a/rust-bindings/hardy-cspcl/src/cla.rs
+++ b/rust-bindings/hardy-cspcl/src/cla.rs
@@ -3,7 +3,6 @@ use cspcl_bindings::CspAddress;
 use hardy_async::async_trait;
 use hardy_bpa::cla::{self, ClaAddress, ClaAddressType, ForwardBundleResult};
 use hardy_bpv7::eid::NodeId;
-use std::sync::Arc;
 use tracing::warn;
 
 use crate::Cla;
@@ -15,17 +14,11 @@ impl cla::Cla for Cla {
     }
 
     async fn on_register(&self, sink: Box<dyn cla::Sink>, _node_ids: &[NodeId]) {
-        let sink: Arc<dyn cla::Sink> = sink.into();
-        let sink = self.sink.call_once(|| sink);
-        let inbound_stream = self.transport.inbound_stream().await;
-        self.runtime
-            .write()
-            .start_inbound(sink.clone(), inbound_stream)
-            .await;
+        self.sink.call_once(|| sink.into());
     }
 
     async fn on_unregister(&self) {
-        self.unregister().await;
+        self.cleanup().await;
     }
 
     async fn forward(

--- a/rust-bindings/hardy-cspcl/src/cla.rs
+++ b/rust-bindings/hardy-cspcl/src/cla.rs
@@ -1,0 +1,55 @@
+use bytes::Bytes;
+use cspcl_bindings::CspAddress;
+use hardy_async::async_trait;
+use hardy_bpa::cla::{self, ClaAddress, ClaAddressType, ForwardBundleResult};
+use hardy_bpv7::eid::NodeId;
+use std::sync::Arc;
+use tracing::warn;
+
+use crate::Cla;
+
+#[async_trait]
+impl cla::Cla for Cla {
+    fn address_type(&self) -> Option<ClaAddressType> {
+        Some(ClaAddressType::Private)
+    }
+
+    async fn on_register(&self, sink: Box<dyn cla::Sink>, _node_ids: &[NodeId]) {
+        let sink: Arc<dyn cla::Sink> = sink.into();
+        let sink = self.sink.call_once(|| sink);
+        let inbound_stream = self.transport.inbound_stream().await;
+        self.runtime
+            .write()
+            .start_inbound(sink.clone(), inbound_stream)
+            .await;
+    }
+
+    async fn on_unregister(&self) {
+        self.unregister().await;
+    }
+
+    async fn forward(
+        &self,
+        _queue: Option<u32>,
+        cla_addr: &ClaAddress,
+        bundle: Bytes,
+    ) -> cla::Result<ForwardBundleResult> {
+        let ClaAddress::Private(raw_addr) = cla_addr else {
+            return Ok(ForwardBundleResult::NoNeighbour);
+        };
+
+        let csp_addr = CspAddress::try_from(raw_addr.clone())
+            .map_err(|e| cla::Error::Internal(Box::new(e)))?;
+
+        match self.transport.send_bundle(bundle, csp_addr).await {
+            Ok(_) => Ok(ForwardBundleResult::Sent),
+            Err(e) => {
+                warn!(
+                    "Failed to send CSP bundle to {}:{}: {e}",
+                    csp_addr.addr, csp_addr.port
+                );
+                Err(cla::Error::Internal(Box::new(e)))
+            }
+        }
+    }
+}

--- a/rust-bindings/hardy-cspcl/src/config.rs
+++ b/rust-bindings/hardy-cspcl/src/config.rs
@@ -1,0 +1,53 @@
+use hardy_bpv7::eid::NodeId;
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+pub enum Interface {
+    Loopback,
+    Can,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default, rename_all = "kebab-case"))]
+pub struct PeerConfig {
+    pub node_id: NodeId,
+    pub addr: u8,
+    pub port: u8,
+    pub heartbeat_interval: Option<u64>,
+}
+
+impl Default for PeerConfig {
+    fn default() -> Self {
+        Self {
+            node_id: "ipn:1.0".parse().expect("valid default node id"),
+            addr: 0,
+            port: 0,
+            heartbeat_interval: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default, rename_all = "kebab-case"))]
+pub struct Config {
+    pub local_addr: u8,
+    pub port: u8,
+    pub interface: Interface,
+    pub interface_name: String,
+    pub peers: Vec<PeerConfig>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            local_addr: 1,
+            port: 0,
+            interface: Interface::Loopback,
+            interface_name: "loopback".to_string(),
+            peers: Vec::new(),
+        }
+    }
+}

--- a/rust-bindings/hardy-cspcl/src/dispatcher.rs
+++ b/rust-bindings/hardy-cspcl/src/dispatcher.rs
@@ -1,43 +1,52 @@
 use cspcl_bindings::{CspAddress, InboundStream};
 use futures_util::TryStreamExt;
-use hardy_async::CancellationToken;
+use hardy_async::{CancellationToken, JoinHandle};
 use std::{collections::HashMap, sync::Arc};
 use tracing::{debug, info, warn};
 
 use hardy_bpa::{
     Bytes,
-    cla::{ClaAddress, Sink},
+    cla::{self, ClaAddress},
 };
 use hardy_bpv7::eid::NodeId;
-use tokio::task::{self, JoinHandle};
+use tokio::task::{self};
 
-pub struct Runtime {
-    pub csp_to_endpoint: HashMap<CspAddress, NodeId>,
-    polling_task: Option<JoinHandle<()>>,
+pub type DispatcherHandle = JoinHandle<()>;
+
+pub struct Dispatcher {
+    csp_to_endpoint: HashMap<CspAddress, NodeId>,
     cancel_polling_task: CancellationToken,
+    inbound: InboundStream,
+    sink: Arc<dyn cla::Sink>,
 }
 
-impl Runtime {
-    pub fn new(csp_to_endpoint: HashMap<CspAddress, NodeId>) -> Self {
+impl Dispatcher {
+    pub fn new(
+        csp_to_endpoint: HashMap<CspAddress, NodeId>,
+        cancel_polling_task: CancellationToken,
+        inbound: InboundStream,
+        sink: Arc<dyn cla::Sink>,
+    ) -> Self {
         Self {
             csp_to_endpoint,
-            polling_task: None,
-            cancel_polling_task: CancellationToken::new(),
+            cancel_polling_task,
+            inbound,
+            sink,
         }
     }
 
-    pub fn stop(&self) {
-        self.cancel_polling_task.cancel();
-    }
-
-    pub async fn start_inbound(&mut self, sink: Arc<dyn Sink>, mut inbound: InboundStream) {
+    pub async fn start_dispatch_inbound_bundle(mut self) -> DispatcherHandle {
         let csp_to_endpoint = self.csp_to_endpoint.clone();
-
         let csp_to_addr_iter = self.csp_to_endpoint.iter();
         for csp_node in csp_to_addr_iter {
             let raw_addr: Bytes = Into::into(*csp_node.0);
-            match sink
-                .add_peer(ClaAddress::Private(raw_addr), &[csp_node.1.clone()])
+            match self
+                .sink
+                .clone()
+                .add_peer(
+                    ClaAddress::Private(raw_addr),
+                    std::slice::from_ref(csp_node.1),
+                )
                 .await
             {
                 Ok(true) => debug!(
@@ -57,13 +66,14 @@ impl Runtime {
         let cancel_token = self.cancel_polling_task.child_token();
 
         info!("Starting polling task of inbound bundle stream");
+        let sink = self.sink.clone();
 
-        let polling_task = task::spawn(async move {
+        task::spawn(async move {
             loop {
                 debug!("Polling Hardy CSPCL inbound stream");
                 let next_bundle = tokio::select! {
                     _ = cancel_token.cancelled() => break,
-                    next_bundle = inbound.try_next() => next_bundle,
+                    next_bundle = self.inbound.try_next() => next_bundle,
                 };
                 let bundle = match next_bundle {
                     Ok(bundle) => match bundle {
@@ -108,7 +118,6 @@ impl Runtime {
                     ),
                 }
             }
-        });
-        self.polling_task = Some(polling_task);
+        })
     }
 }

--- a/rust-bindings/hardy-cspcl/src/dispatcher.rs
+++ b/rust-bindings/hardy-cspcl/src/dispatcher.rs
@@ -35,34 +35,8 @@ impl Dispatcher {
         }
     }
 
-    pub async fn start_dispatch_inbound_bundle(mut self) -> DispatcherHandle {
+    pub fn start_dispatch_inbound_bundle(mut self) -> DispatcherHandle {
         let csp_to_endpoint = self.csp_to_endpoint.clone();
-        let csp_to_addr_iter = self.csp_to_endpoint.iter();
-        for csp_node in csp_to_addr_iter {
-            let raw_addr: Bytes = Into::into(*csp_node.0);
-            match self
-                .sink
-                .clone()
-                .add_peer(
-                    ClaAddress::Private(raw_addr),
-                    std::slice::from_ref(csp_node.1),
-                )
-                .await
-            {
-                Ok(true) => debug!(
-                    "Registered CSP peer {}:{} as {}",
-                    csp_node.0.addr, csp_node.0.port, csp_node.1
-                ),
-                Ok(false) => debug!(
-                    "CSP peer {}:{} was already registered",
-                    csp_node.0.addr, csp_node.0.port
-                ),
-                Err(e) => warn!(
-                    "Failed to register CSP peer {}:{} as {}: {e}",
-                    csp_node.0.addr, csp_node.0.port, csp_node.1
-                ),
-            }
-        }
         let cancel_token = self.cancel_polling_task.child_token();
 
         info!("Starting polling task of inbound bundle stream");

--- a/rust-bindings/hardy-cspcl/src/lib.rs
+++ b/rust-bindings/hardy-cspcl/src/lib.rs
@@ -1,0 +1,129 @@
+mod config;
+mod runtime;
+mod transport;
+
+pub use config::{Config, Interface, PeerConfig};
+
+use hardy_async::async_trait;
+use hardy_async::sync::spin::{Once, RwLock};
+use hardy_bpa::Bytes;
+use hardy_bpa::bpa::BpaRegistration;
+use hardy_bpa::cla::{self, ClaAddress, ClaAddressType, CspAddress, ForwardBundleResult};
+use hardy_bpv7::eid::NodeId;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::{debug, warn};
+
+use crate::runtime::Runtime;
+use crate::transport::Transport;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("transport initialization failed: {0}")]
+    Init(#[from] transport::Error),
+    #[error("registration failed: {0}")]
+    Registration(#[from] cla::Error),
+    #[error("could not create cspcl: {0}")]
+    CscplInit(#[from] cspcl_bindings::Error),
+}
+
+pub struct Cla {
+    transport: transport::Transport,
+    runtime: RwLock<runtime::Runtime>,
+    sink: Once<Arc<dyn cla::Sink>>,
+}
+
+impl Cla {
+    pub fn new(config: &Config) -> Result<Self, Error> {
+        let interface: cspcl_bindings::Interface = match config.interface {
+            Interface::Loopback => cspcl_bindings::Interface::Loopback,
+            Interface::Can => cspcl_bindings::Interface::Can(config.interface_name.clone()),
+        };
+
+        let cspcl = Arc::new(RwLock::new(
+            cspcl_bindings::Cspcl::new(config.local_addr, config.port, interface)
+                .map_err(|e: cspcl_bindings::Error| Error::CscplInit(e))?,
+        ));
+
+        let peers = config.peers.clone();
+        let mut csp_to_endpoint = HashMap::<CspAddress, NodeId>::new();
+        for peer in peers {
+            let csp_address = CspAddress {
+                addr: peer.addr,
+                port: peer.port,
+            };
+            csp_to_endpoint.insert(csp_address, peer.node_id.clone());
+        }
+
+        let transport = Transport::new(cspcl.clone());
+        let runtime = RwLock::new(Runtime::new(csp_to_endpoint));
+
+        Ok(Self {
+            transport,
+            runtime,
+            sink: Once::new(),
+        })
+    }
+
+    pub async fn register(
+        self: &Arc<Self>,
+        bpa: &dyn BpaRegistration,
+        name: String,
+        policy: Option<Arc<dyn hardy_bpa::policy::EgressPolicy>>,
+    ) -> Result<(), Error> {
+        bpa.register_cla(name, self.clone(), policy).await?;
+        Ok(())
+    }
+
+    pub async fn unregister(&self) {
+        debug!("Unregistering cspcl...");
+        self.transport.cleanup();
+        self.runtime.write().stop();
+    }
+}
+
+#[async_trait]
+impl cla::Cla for Cla {
+    fn address_type(&self) -> Option<ClaAddressType> {
+        Some(ClaAddressType::Csp)
+    }
+
+    async fn on_register(&self, sink: Box<dyn cla::Sink>, _node_ids: &[NodeId]) {
+        let sink: Arc<dyn cla::Sink> = sink.into();
+        let sink = self.sink.call_once(|| sink);
+        let inbound_stream = self.transport.inbound_stream().await;
+        self.runtime
+            .write()
+            .start_inbound(sink.clone(), inbound_stream)
+            .await;
+    }
+
+    async fn on_unregister(&self) {
+        self.unregister().await;
+    }
+
+    async fn forward(
+        &self,
+        _queue: Option<u32>,
+        cla_addr: &ClaAddress,
+        bundle: Bytes,
+    ) -> cla::Result<ForwardBundleResult> {
+        let ClaAddress::Csp(csp_addr) = cla_addr else {
+            return Ok(ForwardBundleResult::NoNeighbour);
+        };
+        match self
+            .transport
+            .send_bundle(bundle, csp_addr.addr, csp_addr.port)
+            .await
+        {
+            Ok(_) => Ok(ForwardBundleResult::Sent),
+            Err(e) => {
+                warn!(
+                    "Failed to send CSP bundle to {}:{}: {e}",
+                    csp_addr.addr, csp_addr.port
+                );
+                Err(cla::Error::Internal(Box::new(e)))
+            }
+        }
+    }
+}

--- a/rust-bindings/hardy-cspcl/src/lib.rs
+++ b/rust-bindings/hardy-cspcl/src/lib.rs
@@ -1,19 +1,20 @@
 mod cla;
 mod config;
-mod runtime;
+mod dispatcher;
 mod transport;
 
 pub use config::{Config, Interface, PeerConfig};
 
 use cspcl_bindings::CspAddress;
+use hardy_async::CancellationToken;
 use hardy_async::sync::spin::{Once, RwLock};
-use hardy_bpa::bpa::BpaRegistration;
+use hardy_bpa::cla::Sink;
 use hardy_bpv7::eid::NodeId;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::debug;
 
-use crate::runtime::Runtime;
+use crate::dispatcher::Dispatcher;
 use crate::transport::Transport;
 
 #[derive(thiserror::Error, Debug)]
@@ -24,12 +25,16 @@ pub enum Error {
     Registration(#[from] hardy_bpa::cla::Error),
     #[error("could not create cspcl: {0}")]
     CscplInit(#[from] cspcl_bindings::Error),
+    #[error("Could not create dispatcher: {0}")]
+    Dispatcher(String),
 }
 
 pub struct Cla {
+    csp_to_endpoint: HashMap<CspAddress, NodeId>,
     transport: transport::Transport,
-    runtime: RwLock<runtime::Runtime>,
-    sink: Once<Arc<dyn hardy_bpa::cla::Sink>>,
+    cancel_dispatcher: CancellationToken,
+    sink: Once<Arc<dyn Sink>>,
+    dispatcher: Once<Dispatcher>,
 }
 
 impl Cla {
@@ -59,30 +64,43 @@ impl Cla {
             };
             csp_to_endpoint.insert(csp_address, peer.node_id.clone());
         }
-
         let transport = Transport::new(cspcl.clone());
-        let runtime = RwLock::new(Runtime::new(csp_to_endpoint));
 
         Ok(Self {
+            csp_to_endpoint,
             transport,
-            runtime,
+            cancel_dispatcher: CancellationToken::new(),
             sink: Once::new(),
+            dispatcher: Once::new(),
         })
     }
 
-    pub async fn register(
-        self: &Arc<Self>,
-        bpa: &dyn BpaRegistration,
-        name: String,
-        policy: Option<Arc<dyn hardy_bpa::policy::EgressPolicy>>,
-    ) -> Result<(), Error> {
-        bpa.register_cla(name, self.clone(), policy).await?;
-        Ok(())
+    pub fn build_dispatcher(&self) -> Result<&Dispatcher, Error> {
+        self.dispatcher.get().map_or_else(
+            || -> Result<&Dispatcher, Error> {
+                let inbound = self.transport.inbound_stream();
+                let sink = self
+                    .sink
+                    .get()
+                    .ok_or(Error::Dispatcher("Sink is not initialiazed".to_string()))?;
+
+                let dispatcher = self.dispatcher.call_once(|| {
+                    Dispatcher::new(
+                        self.csp_to_endpoint.clone(),
+                        self.cancel_dispatcher.clone(),
+                        inbound,
+                        sink.clone(),
+                    )
+                });
+                Ok(dispatcher)
+            },
+            Ok,
+        )
     }
 
-    pub async fn unregister(&self) {
+    pub async fn cleanup(&self) {
         debug!("Unregistering cspcl...");
         self.transport.cleanup();
-        self.runtime.write().stop();
+        self.cancel_dispatcher.cancel();
     }
 }

--- a/rust-bindings/hardy-cspcl/src/lib.rs
+++ b/rust-bindings/hardy-cspcl/src/lib.rs
@@ -3,16 +3,18 @@ mod config;
 mod dispatcher;
 mod transport;
 
+use bytes::Bytes;
 pub use config::{Config, Interface, PeerConfig};
 
 use cspcl_bindings::CspAddress;
 use hardy_async::CancellationToken;
 use hardy_async::sync::spin::{Once, RwLock};
-use hardy_bpa::cla::Sink;
+use hardy_bpa::cla::{ClaAddress, Sink};
 use hardy_bpv7::eid::NodeId;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::debug;
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
 
 use crate::dispatcher::Dispatcher;
 use crate::transport::Transport;
@@ -27,6 +29,8 @@ pub enum Error {
     CscplInit(#[from] cspcl_bindings::Error),
     #[error("Could not create dispatcher: {0}")]
     Dispatcher(String),
+    #[error("Sink is not registered")]
+    Sink,
 }
 
 pub struct Cla {
@@ -34,7 +38,6 @@ pub struct Cla {
     transport: transport::Transport,
     cancel_dispatcher: CancellationToken,
     sink: Once<Arc<dyn Sink>>,
-    dispatcher: Once<Dispatcher>,
 }
 
 impl Cla {
@@ -71,31 +74,51 @@ impl Cla {
             transport,
             cancel_dispatcher: CancellationToken::new(),
             sink: Once::new(),
-            dispatcher: Once::new(),
         })
     }
 
-    pub fn build_dispatcher(&self) -> Result<&Dispatcher, Error> {
-        self.dispatcher.get().map_or_else(
-            || -> Result<&Dispatcher, Error> {
-                let inbound = self.transport.inbound_stream();
-                let sink = self
-                    .sink
-                    .get()
-                    .ok_or(Error::Dispatcher("Sink is not initialiazed".to_string()))?;
+    fn sink(&self) -> Result<Arc<dyn Sink>, Error> {
+        self.sink.get().cloned().ok_or(Error::Sink)
+    }
 
-                let dispatcher = self.dispatcher.call_once(|| {
-                    Dispatcher::new(
-                        self.csp_to_endpoint.clone(),
-                        self.cancel_dispatcher.clone(),
-                        inbound,
-                        sink.clone(),
-                    )
-                });
-                Ok(dispatcher)
-            },
-            Ok,
+    pub fn start_dispatcher(&self) -> Result<JoinHandle<()>, Error> {
+        let inbound = self.transport.inbound_stream();
+        let sink = self.sink()?;
+        Ok(Dispatcher::new(
+            self.csp_to_endpoint.clone(),
+            self.cancel_dispatcher.clone(),
+            inbound,
+            sink.clone(),
         )
+        .start_dispatch_inbound_bundle())
+    }
+
+    async fn register_peers(&self) -> Result<(), Error> {
+        let sink = self.sink()?;
+
+        for csp_node in self.csp_to_endpoint.clone().iter() {
+            match sink
+                .add_peer(
+                    ClaAddress::Private(Into::<Bytes>::into(*csp_node.0)),
+                    std::slice::from_ref(csp_node.1),
+                )
+                .await
+            {
+                Ok(true) => debug!(
+                    "Registered CSP peer {}:{} as {}",
+                    csp_node.0.addr, csp_node.0.port, csp_node.1
+                ),
+                Ok(false) => debug!(
+                    "CSP peer {}:{} was already registered",
+                    csp_node.0.addr, csp_node.0.port
+                ),
+                Err(e) => warn!(
+                    "Failed to register CSP peer {}:{} as {}: {e}",
+                    csp_node.0.addr, csp_node.0.port, csp_node.1
+                ),
+            }
+        }
+        Ok(())
     }
 
     pub async fn cleanup(&self) {

--- a/rust-bindings/hardy-cspcl/src/lib.rs
+++ b/rust-bindings/hardy-cspcl/src/lib.rs
@@ -8,7 +8,7 @@ pub use config::{Config, Interface, PeerConfig};
 
 use cspcl_bindings::CspAddress;
 use hardy_async::CancellationToken;
-use hardy_async::sync::spin::{Once, RwLock};
+use hardy_async::sync::spin::Once;
 use hardy_bpa::cla::{ClaAddress, Sink};
 use hardy_bpv7::eid::NodeId;
 use std::collections::HashMap;
@@ -47,7 +47,7 @@ impl Cla {
             Interface::Can => cspcl_bindings::Interface::Can(config.interface_name.clone()),
         };
 
-        let cspcl = Arc::new(RwLock::new(
+        let cspcl = Arc::new(
             cspcl_bindings::Cspcl::new(
                 CspAddress {
                     addr: config.local_addr,
@@ -56,7 +56,7 @@ impl Cla {
                 interface,
             )
             .map_err(|e: cspcl_bindings::Error| Error::CscplInit(e))?,
-        ));
+        );
 
         let peers = config.peers.clone();
         let mut csp_to_endpoint = HashMap::<CspAddress, NodeId>::new();

--- a/rust-bindings/hardy-cspcl/src/lib.rs
+++ b/rust-bindings/hardy-cspcl/src/lib.rs
@@ -1,18 +1,17 @@
+mod cla;
 mod config;
 mod runtime;
 mod transport;
 
 pub use config::{Config, Interface, PeerConfig};
 
-use hardy_async::async_trait;
+use cspcl_bindings::CspAddress;
 use hardy_async::sync::spin::{Once, RwLock};
-use hardy_bpa::Bytes;
 use hardy_bpa::bpa::BpaRegistration;
-use hardy_bpa::cla::{self, ClaAddress, ClaAddressType, CspAddress, ForwardBundleResult};
 use hardy_bpv7::eid::NodeId;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::runtime::Runtime;
 use crate::transport::Transport;
@@ -22,7 +21,7 @@ pub enum Error {
     #[error("transport initialization failed: {0}")]
     Init(#[from] transport::Error),
     #[error("registration failed: {0}")]
-    Registration(#[from] cla::Error),
+    Registration(#[from] hardy_bpa::cla::Error),
     #[error("could not create cspcl: {0}")]
     CscplInit(#[from] cspcl_bindings::Error),
 }
@@ -30,7 +29,7 @@ pub enum Error {
 pub struct Cla {
     transport: transport::Transport,
     runtime: RwLock<runtime::Runtime>,
-    sink: Once<Arc<dyn cla::Sink>>,
+    sink: Once<Arc<dyn hardy_bpa::cla::Sink>>,
 }
 
 impl Cla {
@@ -41,8 +40,14 @@ impl Cla {
         };
 
         let cspcl = Arc::new(RwLock::new(
-            cspcl_bindings::Cspcl::new(config.local_addr, config.port, interface)
-                .map_err(|e: cspcl_bindings::Error| Error::CscplInit(e))?,
+            cspcl_bindings::Cspcl::new(
+                CspAddress {
+                    addr: config.local_addr,
+                    port: config.port,
+                },
+                interface,
+            )
+            .map_err(|e: cspcl_bindings::Error| Error::CscplInit(e))?,
         ));
 
         let peers = config.peers.clone();
@@ -79,51 +84,5 @@ impl Cla {
         debug!("Unregistering cspcl...");
         self.transport.cleanup();
         self.runtime.write().stop();
-    }
-}
-
-#[async_trait]
-impl cla::Cla for Cla {
-    fn address_type(&self) -> Option<ClaAddressType> {
-        Some(ClaAddressType::Csp)
-    }
-
-    async fn on_register(&self, sink: Box<dyn cla::Sink>, _node_ids: &[NodeId]) {
-        let sink: Arc<dyn cla::Sink> = sink.into();
-        let sink = self.sink.call_once(|| sink);
-        let inbound_stream = self.transport.inbound_stream().await;
-        self.runtime
-            .write()
-            .start_inbound(sink.clone(), inbound_stream)
-            .await;
-    }
-
-    async fn on_unregister(&self) {
-        self.unregister().await;
-    }
-
-    async fn forward(
-        &self,
-        _queue: Option<u32>,
-        cla_addr: &ClaAddress,
-        bundle: Bytes,
-    ) -> cla::Result<ForwardBundleResult> {
-        let ClaAddress::Csp(csp_addr) = cla_addr else {
-            return Ok(ForwardBundleResult::NoNeighbour);
-        };
-        match self
-            .transport
-            .send_bundle(bundle, csp_addr.addr, csp_addr.port)
-            .await
-        {
-            Ok(_) => Ok(ForwardBundleResult::Sent),
-            Err(e) => {
-                warn!(
-                    "Failed to send CSP bundle to {}:{}: {e}",
-                    csp_addr.addr, csp_addr.port
-                );
-                Err(cla::Error::Internal(Box::new(e)))
-            }
-        }
     }
 }

--- a/rust-bindings/hardy-cspcl/src/runtime.rs
+++ b/rust-bindings/hardy-cspcl/src/runtime.rs
@@ -1,0 +1,109 @@
+use cspcl_bindings::InboundStream;
+use futures_util::TryStreamExt;
+use hardy_async::CancellationToken;
+use std::{collections::HashMap, sync::Arc};
+use tracing::{debug, info, warn};
+
+use hardy_bpa::{
+    Bytes,
+    cla::{ClaAddress, CspAddress, Sink},
+};
+use hardy_bpv7::eid::NodeId;
+use tokio::task::{self, JoinHandle};
+
+pub struct Runtime {
+    pub csp_to_endpoint: HashMap<CspAddress, NodeId>,
+    polling_task: Option<JoinHandle<()>>,
+    cancel_polling_task: CancellationToken,
+}
+
+impl Runtime {
+    pub fn new(csp_to_endpoint: HashMap<CspAddress, NodeId>) -> Self {
+        Self {
+            csp_to_endpoint,
+            polling_task: None,
+            cancel_polling_task: CancellationToken::new(),
+        }
+    }
+
+    pub fn stop(&self) {
+        self.cancel_polling_task.cancel();
+    }
+
+    pub async fn start_inbound(&mut self, sink: Arc<dyn Sink>, mut inbound: InboundStream) {
+        let csp_to_endpoint = self.csp_to_endpoint.clone();
+
+        let csp_to_addr_iter = self.csp_to_endpoint.iter();
+        for csp_node in csp_to_addr_iter {
+            match sink
+                .add_peer(ClaAddress::Csp(*csp_node.0), &[csp_node.1.clone()])
+                .await
+            {
+                Ok(true) => debug!(
+                    "Registered CSP peer {}:{} as {}",
+                    csp_node.0.addr, csp_node.0.port, csp_node.1
+                ),
+                Ok(false) => debug!(
+                    "CSP peer {}:{} was already registered",
+                    csp_node.0.addr, csp_node.0.port
+                ),
+                Err(e) => warn!(
+                    "Failed to register CSP peer {}:{} as {}: {e}",
+                    csp_node.0.addr, csp_node.0.port, csp_node.1
+                ),
+            }
+        }
+        let cancel_token = self.cancel_polling_task.child_token();
+
+        info!("Starting polling task of inbound bundle stream");
+
+        let polling_task = task::spawn(async move {
+            loop {
+                debug!("Polling Hardy CSPCL inbound stream");
+                let next_bundle = tokio::select! {
+                    _ = cancel_token.cancelled() => break,
+                    next_bundle = inbound.try_next() => next_bundle,
+                };
+                let bundle = match next_bundle {
+                    Ok(bundle) => match bundle {
+                        Some(bundle) => bundle,
+                        None => {
+                            debug!("Hardy CSPCL inbound stream closed");
+                            break;
+                        }
+                    },
+                    Err(e) => {
+                        warn!("Error occured when receiving bundle: {}", e.to_string());
+                        continue;
+                    }
+                };
+                debug!(
+                    len = bundle.data.len(),
+                    "New bundle in inbound stream from {}:{}", bundle.src_addr, bundle.src_port
+                );
+                let bundle_data: Bytes = bundle.data.into();
+                let csp_peer_addr = CspAddress {
+                    addr: bundle.src_addr,
+                    port: bundle.src_port,
+                };
+                let node_id = csp_to_endpoint.get(&csp_peer_addr);
+                match sink
+                    .dispatch(bundle_data, node_id, Some(&ClaAddress::Csp(csp_peer_addr)))
+                    .await
+                {
+                    Ok(()) => info!(
+                        peer_node = node_id.map(|node_id| node_id.to_string()),
+                        "Dispatched inbound CSP bundle from {}:{} to BPA",
+                        csp_peer_addr.addr,
+                        csp_peer_addr.port
+                    ),
+                    Err(e) => warn!(
+                        "Failed to dispatch inbound CSP bundle from {}:{} to BPA: {e}",
+                        csp_peer_addr.addr, csp_peer_addr.port
+                    ),
+                }
+            }
+        });
+        self.polling_task = Some(polling_task);
+    }
+}

--- a/rust-bindings/hardy-cspcl/src/runtime.rs
+++ b/rust-bindings/hardy-cspcl/src/runtime.rs
@@ -1,4 +1,4 @@
-use cspcl_bindings::InboundStream;
+use cspcl_bindings::{CspAddress, InboundStream};
 use futures_util::TryStreamExt;
 use hardy_async::CancellationToken;
 use std::{collections::HashMap, sync::Arc};
@@ -6,7 +6,7 @@ use tracing::{debug, info, warn};
 
 use hardy_bpa::{
     Bytes,
-    cla::{ClaAddress, CspAddress, Sink},
+    cla::{ClaAddress, Sink},
 };
 use hardy_bpv7::eid::NodeId;
 use tokio::task::{self, JoinHandle};
@@ -35,8 +35,9 @@ impl Runtime {
 
         let csp_to_addr_iter = self.csp_to_endpoint.iter();
         for csp_node in csp_to_addr_iter {
+            let raw_addr: Bytes = Into::into(*csp_node.0);
             match sink
-                .add_peer(ClaAddress::Csp(*csp_node.0), &[csp_node.1.clone()])
+                .add_peer(ClaAddress::Private(raw_addr), &[csp_node.1.clone()])
                 .await
             {
                 Ok(true) => debug!(
@@ -88,7 +89,11 @@ impl Runtime {
                 };
                 let node_id = csp_to_endpoint.get(&csp_peer_addr);
                 match sink
-                    .dispatch(bundle_data, node_id, Some(&ClaAddress::Csp(csp_peer_addr)))
+                    .dispatch(
+                        bundle_data,
+                        node_id,
+                        Some(&ClaAddress::Private(csp_peer_addr.into())),
+                    )
                     .await
                 {
                     Ok(()) => info!(

--- a/rust-bindings/hardy-cspcl/src/transport.rs
+++ b/rust-bindings/hardy-cspcl/src/transport.rs
@@ -36,8 +36,8 @@ impl Transport {
             .map_err(Error::Send)
     }
 
-    pub async fn inbound_stream(&self) -> InboundStream {
-        self.cspcl.read().clone().inbound().await
+    pub fn inbound_stream(&self) -> InboundStream {
+        self.cspcl.read().clone().inbound()
     }
 
     pub fn cleanup(&self) {

--- a/rust-bindings/hardy-cspcl/src/transport.rs
+++ b/rust-bindings/hardy-cspcl/src/transport.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use cspcl_bindings::{Error as CspclError, InboundStream};
+use cspcl_bindings::{CspAddress, Error as CspclError, InboundStream};
 use hardy_async::sync::spin::RwLock;
 use tracing::debug;
 
@@ -27,13 +27,12 @@ impl Transport {
     pub async fn send_bundle(
         &self,
         payload: impl Into<Vec<u8>>,
-        addr: u8,
-        port: u8,
+        dest: CspAddress,
     ) -> Result<(), Error> {
-        debug!("Try sending bundle to: {}:{}", addr, port);
+        debug!("Try sending bundle to: {}:{}", dest.addr, dest.port);
         self.cspcl
             .write()
-            .send_bundle(&payload.into(), addr, port)
+            .send_bundle(&payload.into(), dest)
             .map_err(Error::Send)
     }
 

--- a/rust-bindings/hardy-cspcl/src/transport.rs
+++ b/rust-bindings/hardy-cspcl/src/transport.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use cspcl_bindings::{CspAddress, Error as CspclError, InboundStream};
-use hardy_async::sync::spin::RwLock;
 use tracing::debug;
 
 #[derive(Debug, thiserror::Error)]
@@ -16,11 +15,11 @@ pub enum Error {
 
 #[derive(Clone)]
 pub struct Transport {
-    cspcl: Arc<RwLock<cspcl_bindings::Cspcl>>,
+    cspcl: Arc<cspcl_bindings::Cspcl>,
 }
 
 impl Transport {
-    pub fn new(cspcl: Arc<RwLock<cspcl_bindings::Cspcl>>) -> Self {
+    pub fn new(cspcl: Arc<cspcl_bindings::Cspcl>) -> Self {
         Self { cspcl }
     }
 
@@ -31,17 +30,15 @@ impl Transport {
     ) -> Result<(), Error> {
         debug!("Try sending bundle to: {}:{}", dest.addr, dest.port);
         self.cspcl
-            .write()
             .send_bundle(&payload.into(), dest)
             .map_err(Error::Send)
     }
 
     pub fn inbound_stream(&self) -> InboundStream {
-        self.cspcl.read().clone().inbound()
+        Arc::clone(&self.cspcl).inbound()
     }
 
     pub fn cleanup(&self) {
-        let cspcl = self.cspcl.write();
-        drop(cspcl);
+        self.cspcl.close_rx_socket();
     }
 }

--- a/rust-bindings/hardy-cspcl/src/transport.rs
+++ b/rust-bindings/hardy-cspcl/src/transport.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+
+use cspcl_bindings::{Error as CspclError, InboundStream};
+use hardy_async::sync::spin::RwLock;
+use tracing::debug;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("transport init failed: {0}")]
+    Init(#[from] CspclError),
+    #[error("transport send failed: {0}")]
+    Send(#[source] CspclError),
+    #[error("transport receive failed: {0}")]
+    Recv(#[source] CspclError),
+}
+
+#[derive(Clone)]
+pub struct Transport {
+    cspcl: Arc<RwLock<cspcl_bindings::Cspcl>>,
+}
+
+impl Transport {
+    pub fn new(cspcl: Arc<RwLock<cspcl_bindings::Cspcl>>) -> Self {
+        Self { cspcl }
+    }
+
+    pub async fn send_bundle(
+        &self,
+        payload: impl Into<Vec<u8>>,
+        addr: u8,
+        port: u8,
+    ) -> Result<(), Error> {
+        debug!("Try sending bundle to: {}:{}", addr, port);
+        self.cspcl
+            .write()
+            .send_bundle(&payload.into(), addr, port)
+            .map_err(Error::Send)
+    }
+
+    pub async fn inbound_stream(&self) -> InboundStream {
+        self.cspcl.read().clone().inbound().await
+    }
+
+    pub fn cleanup(&self) {
+        let cspcl = self.cspcl.write();
+        drop(cspcl);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Hardy routing agent backed by **A-SABR** (`hardy-a-sabr`) plus a gRPC server crate (`hardy-a-sabr-server`), and brings the crate current with the rebuilt **A-SABR PR #66** routing/pathfinding API.

The agent builds an ephemeral "shadow" contact-graph per query, computes the first hop toward each projected destination via A-SABR, and installs the results as `RouteAction::Via` routes through the Hardy `RoutingSink`. An async scheduler refreshes routes at contact boundaries and on a safety tick.

## A-SABR PR #66 migration (latest work on this branch)

The upstream A-SABR routing surface was rebuilt (PR #66). This branch adapts to it:

- **Dependency** pinned to the PR #66 merge rev (`16ffed5`).
- **Routing** now goes through `a_sabr::utils::Router` + `route()` with a generativity-guarded ephemeral graph, SPSN / hybrid-parenting / SABR distance, and a `RoutableNodeRef` unicast destination. First hop is extracted from the returned `PathFragment`.
- **Time model** migrated from `f64` seconds to **`i64` milliseconds** end-to-end (topology, projection, scheduler clock, bundle expiration, config, sample YAML) to match A-SABR's native units.
- `ShadowEngineConfig` reduced to `{ max_entries }`; priority handled by the fixed `PRIO_COUNT = 1` const.
- Non-contiguous `asabr_node_id` topologies now fail loudly at runtime (`ASABRError::ContactPlanError`) rather than silently misrouting.

Design + plan: `docs/superpowers/specs/2026-07-22-a-sabr-pr66-migration-design.md`, `docs/superpowers/plans/2026-07-22-a-sabr-pr66-migration.md`.

## Testing

- `hardy-a-sabr` + `hardy-a-sabr-server`: build clean, `cargo test` passes (3/3), `cargo clippy -D warnings` clean, `--features serde` builds.
- Whole-workspace `cargo build/test` requires the `cspcl-sys` native dep (`libcsp`), unrelated to this work.

## Follow-ups (non-blocking)

- `build_contact_plan` `filter_map` silently drops invalid nodes/contacts — consider surfacing as errors/warnings.
- `project_routes` rebuilds the `ContactPlan` + `Router` per destination; the new API could route to multiple destinations against one graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
